### PR TITLE
fix resources:directory to not require a resources subdir

### DIFF
--- a/internal/engine/resources_test.go
+++ b/internal/engine/resources_test.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/PDOK/gomagpie/config"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
@@ -18,6 +20,53 @@ type MockReverseProxy struct {
 
 func (m *MockReverseProxy) Proxy(w http.ResponseWriter, r *http.Request, target *url.URL, prefer204 bool, overwrite string) {
 	m.Called(w, r, target, prefer204, overwrite)
+}
+
+func TestDir(t *testing.T) {
+	tests := []struct {
+		name           string
+		resourcesDir   string
+		urlParam       string
+		expectedStatus int
+		expectedLog    string
+	}{
+		{
+			name:           "valid url",
+			resourcesDir:   "docs",
+			urlParam:       "gomagpie.jpeg",
+			expectedStatus: http.StatusOK,
+			expectedLog:    "",
+		},
+		{
+			name:           "invalid url",
+			resourcesDir:   "docs",
+			urlParam:       "non-existing-file",
+			expectedStatus: http.StatusNotFound,
+			expectedLog:    "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// given
+			engine, err := NewEngine("internal/engine/testdata/config_minimal.yaml", false, true)
+			assert.NoError(t, err)
+			engine.Config.Resources = &config.Resources{Directory: &tt.resourcesDir}
+			r := httptest.NewRequest(http.MethodGet, "/resources/"+tt.urlParam, nil)
+			w := httptest.NewRecorder()
+			var logOutput strings.Builder
+			log.SetOutput(&logOutput)
+
+			// when
+			newResourcesEndpoint(engine)
+			engine.Router.ServeHTTP(w, r)
+
+			// then
+			assert.Equal(t, tt.expectedStatus, w.Result().StatusCode)
+			if tt.expectedLog != "" {
+				assert.Contains(t, logOutput.String(), tt.expectedLog)
+			}
+		})
+	}
 }
 
 func TestProxy(t *testing.T) {


### PR DESCRIPTION
# Description

add test for fix resources:directory to not require a resources subdir

## Type of change

- Minor change (typo, formatting, version bump)

# Checklist:

- [x] I've double-checked the code in this PR myself
- [ ] I've left the code better than before ([boy scout rule](https://wiki.c2.com/?BoyScoutRule))
- [ ] The code is readable, comments are added that explain hard or non-obvious parts.
- [x] I've expanded/improved the (unit) tests, when applicable
- [x] I've run (unit) tests that prove my solution works
- [x] There's no sensitive information like credentials in my PR