### PR TITLE
add collection-id arg to import-file

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -185,3 +185,12 @@ func isExistingLocalDir(path string) bool {
 	fileInfo, err := os.Stat(path)
 	return err == nil && fileInfo.IsDir()
 }
+
+func CollectionByID(cfg *Config, id string) *GeoSpatialCollection {
+	for _, coll := range cfg.Collections {
+		if coll.ID == id {
+			return &coll
+		}
+	}
+	return nil
+}

--- a/internal/etl/etl.go
+++ b/internal/etl/etl.go
@@ -52,14 +52,10 @@ func CreateSearchIndex(dbConn string, searchIndex string) error {
 }
 
 // ImportFile import source data into target search index using extract-transform-load principle
-func ImportFile(cfg *config.Config, searchIndex string, filePath string, table config.FeatureTable,
+func ImportFile(collection config.GeoSpatialCollection, searchIndex string, filePath string, table config.FeatureTable,
 	pageSize int, dbConn string) error {
 
 	log.Println("start importing")
-	collection, err := getCollectionForTable(cfg, table)
-	if err != nil {
-		return err
-	}
 	if collection.Search == nil {
 		return fmt.Errorf("no search configuration found for feature table: %s", table.Name)
 	}
@@ -122,13 +118,4 @@ func newTargetToLoad(dbConn string) (Load, error) {
 
 func newTransformer() Transform {
 	return t.Transformer{}
-}
-
-func getCollectionForTable(cfg *config.Config, table config.FeatureTable) (config.GeoSpatialCollection, error) {
-	for _, coll := range cfg.Collections {
-		if coll.ID == table.Name {
-			return coll, nil
-		}
-	}
-	return config.GeoSpatialCollection{}, fmt.Errorf("no configured collection for feature table: %s", table)
 }

--- a/internal/etl/etl_test.go
+++ b/internal/etl/etl_test.go
@@ -84,6 +84,8 @@ func TestImportGeoPackage(t *testing.T) {
 			t.Error(err)
 		}
 		assert.NotNil(t, cfg)
+		collection := config.CollectionByID(cfg, "addresses")
+		assert.NotNil(t, collection)
 		for _, collection := range cfg.Collections {
 			if collection.Search != nil {
 				collection.Search.ETL.Filter = tt.where
@@ -95,7 +97,7 @@ func TestImportGeoPackage(t *testing.T) {
 		assert.NoError(t, err)
 
 		table := config.FeatureTable{Name: "addresses", FID: "fid", Geom: "geom"}
-		err = ImportFile(cfg, "search_index", pwd+"/testdata/addresses-crs84.gpkg", table, 1000, dbConn)
+		err = ImportFile(*collection, "search_index", pwd+"/testdata/addresses-crs84.gpkg", table, 1000, dbConn)
 		assert.NoError(t, err)
 
 		// check nr of records


### PR DESCRIPTION
# Description

add collection-id arg to import-file

because collection is not always equal to table name in import file

PDOK-17220

## Type of change

- Improvement of existing feature

# Checklist:

- [x] I've double-checked the code in this PR myself
- [ ] I've left the code better than before ([boy scout rule](https://wiki.c2.com/?BoyScoutRule))
- [ ] The code is readable, comments are added that explain hard or non-obvious parts.
- [ ] I've expanded/improved the (unit) tests, when applicable
- [ ] I've run (unit) tests that prove my solution works
- [ ] There's no sensitive information like credentials in my PR