### PR TITLE
fix: disable partitioning in unit test, since partitioning is impleme…

### DIFF
--- a/internal/etl/etl_test.go
+++ b/internal/etl/etl_test.go
@@ -162,21 +162,22 @@ func insertTestData(ctx context.Context, conn string) error {
 	}
 	defer db.Close(ctx)
 
-	// Create required partitions for testData
-	//nolint:misspell
-	partitions := `
-	create table search_index_addres partition of search_index
-		for values in ('adres');
-		-- partition by list(collection_version);
-	create table search_index_weg partition of search_index
-		for values in ('weg');
-		-- partition by list(collection_version);
-    `
-
-	_, err = db.Exec(ctx, partitions)
-	if err != nil {
-		log.Printf("Error creating partitions: %v\n", err)
-	}
+	// TODO: Disabled since partitioning is disabled for now (see)
+	// // Create required partitions for testData
+	// //nolint:misspell
+	// partitions := `
+	// create table search_index_addres partition of search_index
+	// 	for values in ('adres');
+	// 	-- partition by list(collection_version);
+	// create table search_index_weg partition of search_index
+	// 	for values in ('weg');
+	// 	-- partition by list(collection_version);
+	// `
+	//
+	// _, err = db.Exec(ctx, partitions)
+	// if err != nil {
+	// 	log.Printf("Error creating partitions: %v\n", err)
+	// }
 
 	testData := `
 	insert into search_index(feature_id, collection_id, collection_version, display_name, suggest, geometry_type, bbox)


### PR DESCRIPTION

# Description

Resolve error in unit test by:
Disable partitioning in unit test, since partitioning is implemented later.

## Type of change

- Minor change (typo, formatting, version bump)

# Checklist:

- [x] I've double-checked the code in this PR myself
- [ ] I've left the code better than before ([boy scout rule](https://wiki.c2.com/?BoyScoutRule))
- [ ] The code is readable, comments are added that explain hard or non-obvious parts.
- [ ] I've expanded/improved the (unit) tests, when applicable
- [x] I've run (unit) tests that prove my solution works
- [ ] There's no sensitive information like credentials in my PR