### PR TITLE
feat: make create search index idempotent, it shouldn't fail when it's already there.

### DIFF
--- a/internal/etl/load/postgres.go
+++ b/internal/etl/load/postgres.go
@@ -49,7 +49,14 @@ func (p *Postgres) Load(records []t.SearchIndexRecord, index string) (int64, err
 
 // Init initialize search index
 func (p *Postgres) Init(index string) error {
-	geometryType := `create type geometry_type as enum ('POINT', 'MULTIPOINT', 'LINESTRING', 'MULTILINESTRING', 'POLYGON', 'MULTIPOLYGON');`
+	// since "create type if not exists" isn't supported by Postgres we use a bit
+	// of pl/pgsql to avoid to create the geometry_type in an idempotent way
+	geometryType := `
+		do $$ begin
+		    create type geometry_type as enum ('POINT', 'MULTIPOINT', 'LINESTRING', 'MULTILINESTRING', 'POLYGON', 'MULTIPOLYGON');
+		exception
+		    when duplicate_object then null;
+		end $$;`
 	_, err := p.db.Exec(p.ctx, geometryType)
 	if err != nil {
 		return fmt.Errorf("error creating geometry type: %w", err)
@@ -73,14 +80,14 @@ func (p *Postgres) Init(index string) error {
 	}
 
 	fullTextSearchColumn := fmt.Sprintf(`
-		alter table %[1]s add column ts tsvector 
+		alter table %[1]s add column if not exists ts tsvector 
 	    generated always as (to_tsvector('dutch', suggest || display_name )) stored;`, index)
 	_, err = p.db.Exec(p.ctx, fullTextSearchColumn)
 	if err != nil {
 		return fmt.Errorf("error creating full-text search column: %w", err)
 	}
 
-	ginIndex := fmt.Sprintf(`create index ts_idx on  %[1]s using gin(ts);`, index)
+	ginIndex := fmt.Sprintf(`create index if not exists ts_idx on  %[1]s using gin(ts);`, index)
 	_, err = p.db.Exec(p.ctx, ginIndex)
 	if err != nil {
 		return fmt.Errorf("error creating GIN index: %w", err)

--- a/internal/etl/load/postgres.go
+++ b/internal/etl/load/postgres.go
@@ -50,7 +50,7 @@ func (p *Postgres) Load(records []t.SearchIndexRecord, index string) (int64, err
 // Init initialize search index
 func (p *Postgres) Init(index string) error {
 	// since "create type if not exists" isn't supported by Postgres we use a bit
-	// of pl/pgsql to avoid to creating the geometry_type when it already exists.
+	// of pl/pgsql to avoid creating the geometry_type when it already exists.
 	geometryType := `
 		do $$ begin
 		    create type geometry_type as enum ('POINT', 'MULTIPOINT', 'LINESTRING', 'MULTILINESTRING', 'POLYGON', 'MULTIPOLYGON');

--- a/internal/etl/load/postgres.go
+++ b/internal/etl/load/postgres.go
@@ -50,7 +50,7 @@ func (p *Postgres) Load(records []t.SearchIndexRecord, index string) (int64, err
 // Init initialize search index
 func (p *Postgres) Init(index string) error {
 	// since "create type if not exists" isn't supported by Postgres we use a bit
-	// of pl/pgsql to avoid to create the geometry_type in an idempotent way
+	// of pl/pgsql to avoid to creating the geometry_type when it already exists.
 	geometryType := `
 		do $$ begin
 		    create type geometry_type as enum ('POINT', 'MULTIPOINT', 'LINESTRING', 'MULTILINESTRING', 'POLYGON', 'MULTIPOLYGON');


### PR DESCRIPTION
# Description

make create search index idempotent, it shouldn't fail when it's already there.

## Type of change

- Improvement of existing feature

# Checklist:

- [ ] I've double-checked the code in this PR myself
- [ ] I've left the code better than before ([boy scout rule](https://wiki.c2.com/?BoyScoutRule))
- [ ] The code is readable, comments are added that explain hard or non-obvious parts.
- [ ] I've expanded/improved the (unit) tests, when applicable
- [ ] I've run (unit) tests that prove my solution works
- [ ] There's no sensitive information like credentials in my PR