### PR TITLE
feat: improve order of search results to include collection specific fields

### DIFF
--- a/config/collections.go
+++ b/config/collections.go
@@ -78,6 +78,9 @@ type Search struct {
 	// +kubebuilder:validation:MinItems=1
 	OGCCollections []RelatedOGCAPIFeaturesCollection `yaml:"ogcCollections" json:"ogcCollections" validate:"required,min=1"`
 
+	// Sort order of the fields when displaying search results
+	OrderBy OrderByFields `yaml:"orderBy,omitempty" json:"orderBy,omitempty" validate:"required"`
+
 	ETL SearchETL `yaml:"etl" json:"etl" validate:"required"`
 }
 
@@ -108,6 +111,14 @@ type RelatedOGCAPIFeaturesCollection struct {
 	// E.g.: "{now()-1h}"
 	// +optional
 	Datetime *string `yaml:"datetime,omitempty" json:"datetime,omitempty"`
+}
+
+type OrderByFields struct {
+	// The fields to be sorted in ascending order
+	Asc []string `yaml:"asc,omitempty" json:"asc,omitempty"` // validate:"required_without=Desc"
+
+	// The fields to be sorted in descending order
+	Desc []string `yaml:"desc,omitempty" json:"desc,omitempty"`
 }
 
 type CollectionLinks struct {

--- a/internal/etl/etl.go
+++ b/internal/etl/etl.go
@@ -74,7 +74,7 @@ func ImportFile(collection config.GeoSpatialCollection, searchIndex string, file
 	}
 	defer target.Close()
 
-	transformer, err := newTransformer(substitutionsFile, synonymsFile)
+	transformer, err := newTransformer(substitutionsFile, synonymsFile, collection.Search.OrderBy)
 	if err != nil {
 		return err
 	}
@@ -126,6 +126,6 @@ func newTargetToLoad(dbConn string) (Load, error) {
 	return nil, fmt.Errorf("unsupported target database connection: %s", dbConn)
 }
 
-func newTransformer(substitutionsFile string, synonymsFile string) (Transform, error) {
-	return t.NewTransformer(substitutionsFile, synonymsFile)
+func newTransformer(substitutionsFile string, synonymsFile string, orderByFields config.OrderByFields) (Transform, error) {
+	return t.NewTransformer(substitutionsFile, synonymsFile, orderByFields)
 }

--- a/internal/etl/load/postgres.go
+++ b/internal/etl/load/postgres.go
@@ -35,10 +35,10 @@ func (p *Postgres) Load(records []t.SearchIndexRecord, index string) (int64, err
 	loaded, err := p.db.CopyFrom(
 		p.ctx,
 		pgx.Identifier{index},
-		[]string{"feature_id", "collection_id", "collection_version", "display_name", "suggest", "geometry_type", "bbox"},
+		[]string{"feature_id", "collection_id", "collection_version", "display_name", "suggest", "geometry_type", "bbox", "order_by"},
 		pgx.CopyFromSlice(len(records), func(i int) ([]interface{}, error) {
 			r := records[i]
-			return []any{r.FeatureID, r.CollectionID, r.CollectionVersion, r.DisplayName, r.Suggest, r.GeometryType, r.Bbox}, nil
+			return []any{r.FeatureID, r.CollectionID, r.CollectionVersion, r.DisplayName, r.Suggest, r.GeometryType, r.Bbox, r.OrderBy}, nil
 		}),
 	)
 	if err != nil {
@@ -65,13 +65,14 @@ func (p *Postgres) Init(index string) error {
 	searchIndexTable := fmt.Sprintf(`
 	create table if not exists %[1]s (
 		id 					serial,
-		feature_id 			text 					not null ,
-		collection_id 		text					not null,
-		collection_version 	int 					not null,
-		display_name 		text					not null,
-		suggest 			text					not null,
-		geometry_type 		geometry_type			not null,
-		bbox 				geometry(polygon, %[2]d) null,
+		feature_id 			text 						not null,
+		collection_id 		text						not null,
+		collection_version 	int 						not null,
+		display_name 		text						not null,
+		suggest 			text						not null,
+		geometry_type 		geometry_type				not null,
+		bbox 				geometry(polygon, %[2]d) 	null,
+	    order_by			jsonb						not null,
 		primary key (id, collection_id, collection_version)
 	) -- partition by list(collection_id);`, index, t.WGS84) // TODO partitioning comes later
 	_, err = p.db.Exec(p.ctx, searchIndexTable)

--- a/internal/etl/testdata/config.yaml
+++ b/internal/etl/testdata/config.yaml
@@ -21,6 +21,11 @@ collections:
         - component_thoroughfarename
         - component_postaldescriptor
         - component_addressareaname
+      orderBy:
+        asc:
+          - component_thoroughfarename
+        desc:
+          - component_postaldescriptor
       displayNameTemplate: "{{ .component_thoroughfarename }} - {{ .component_addressareaname | firstupper }}"
       etl:
         suggestTemplates:

--- a/internal/search/datasources/datasource.go
+++ b/internal/search/datasources/datasource.go
@@ -11,8 +11,7 @@ import (
 type Datasource interface {
 	// SearchFeaturesAcrossCollections search features in one or more collections. Collections can be located
 	// in this dataset or in other datasets.
-	SearchFeaturesAcrossCollections(ctx context.Context, searchTerm string, collections domain.CollectionsWithParams,
-		srid domain.SRID, limit int) (*domain.FeatureCollection, error)
+	SearchFeaturesAcrossCollections(ctx context.Context, searchTerm string, collections domain.CollectionsWithParams, srid domain.SRID, limit int, orderBy []string, clause2 []string) (*domain.FeatureCollection, error)
 
 	// Close closes (connections to) the datasource gracefully
 	Close()

--- a/internal/search/domain/search.go
+++ b/internal/search/domain/search.go
@@ -1,6 +1,8 @@
 package domain
 
-import "strconv"
+import (
+	"strconv"
+)
 
 const (
 	VersionParam     = "version"

--- a/internal/search/testdata/config.yaml
+++ b/internal/search/testdata/config.yaml
@@ -24,6 +24,11 @@ collections:
         - locator_designator_addressnumber
         - locator_designator_addressnumberextension
         - locator_designator_addressnumber2ndextension
+      orderBy:
+        asc:
+          - component_thoroughfarename
+        desc:
+          - component_postaldescriptor
       displayNameTemplate: "{{ .component_thoroughfarename }} - {{ .component_addressareaname | firstupper }} {{ .locator_designator_addressnumber }} {{ .locator_designator_addressnumberextension }} {{ .locator_designator_addressnumber2ndextension }}"
       etl:
         suggestTemplates:


### PR DESCRIPTION
# Description

improve order of search results to include collection specific fields, besides the standard rank and display name

## Type of change

- New feature
- Improvement of existing feature

# Checklist:

- [ ] I've double-checked the code in this PR myself
- [ ] I've left the code better than before ([boy scout rule](https://wiki.c2.com/?BoyScoutRule))
- [ ] The code is readable, comments are added that explain hard or non-obvious parts.
- [ ] I've expanded/improved the (unit) tests, when applicable
- [ ] I've run (unit) tests that prove my solution works
- [ ] There's no sensitive information like credentials in my PR