### PR TITLE
fix: add external_fid fields to extract

### DIFF
--- a/config/collections.go
+++ b/config/collections.go
@@ -102,7 +102,7 @@ type ExternalFid struct {
 	UUIDNamespace uuid.UUID `yaml:"uuidNamespace,omitempty" json:"uuidNamespace,omitempty" default:"6ba7b811-9dad-11d1-80b4-00c04fd430c8" validate:"required"`
 
 	// Fields used to generate external_fid in the target OGC Features Collection(s).
-	// If feature ID should be used, always specify it as 'fid'!
+	// Field names should match those in the source datasource.
 	Fields []string `yaml:"fields" json:"fields" validate:"required"`
 }
 

--- a/internal/etl/etl.go
+++ b/internal/etl/etl.go
@@ -16,7 +16,7 @@ import (
 type Extract interface {
 
 	// Extract raw records from source database to be transformed and loaded into target search index
-	Extract(table config.FeatureTable, fields []string, where string, limit int, offset int) ([]t.RawRecord, error)
+	Extract(table config.FeatureTable, fields []string, externaFidFields []string, where string, limit int, offset int) ([]t.RawRecord, error)
 
 	// Close connection to source database
 	Close()
@@ -85,7 +85,11 @@ func ImportFile(collection config.GeoSpatialCollection, searchIndex string, file
 	for {
 		log.Println("---")
 		log.Printf("extracting source records from offset %d", offset)
-		sourceRecords, err := source.Extract(table, collection.Search.Fields, collection.Search.ETL.Filter, pageSize, offset)
+		externalFidFields := []string{}
+		if collection.Search.ETL.ExternalFid != nil {
+			externalFidFields = collection.Search.ETL.ExternalFid.Fields
+		}
+		sourceRecords, err := source.Extract(table, collection.Search.Fields, externalFidFields, collection.Search.ETL.Filter, pageSize, offset)
 		if err != nil {
 			return fmt.Errorf("failed extracting source records: %w", err)
 		}

--- a/internal/etl/testdata/config.yaml
+++ b/internal/etl/testdata/config.yaml
@@ -28,9 +28,9 @@ collections:
           - "{{ .component_thoroughfarename }} {{ .component_addressareaname }}"
           - "{{ .component_thoroughfarename }}, {{ .component_postaldescriptor }} {{ .component_addressareaname }}"
         externalFid:
-          uuidNamespace: "098c4e26-6e36-5693-bae9-df35db0bee49"
+          uuidNamespace: 098c4e26-6e36-5693-bae9-df35db0bee49
           fields:
-            - "fid"
+            - fid
       ogcCollections:
         - api: https://example.com/ogc/v1
           collection: addresses


### PR DESCRIPTION
# Description

Add fields specified for `external_fid` to extract, so that they are available for generation of `external_fid`.

## Type of change

(Remove irrelevant options)

- Improvement of existing feature
- Bugfix

# Checklist:

- [x] I've double-checked the code in this PR myself
- [x] I've left the code better than before ([boy scout rule](https://wiki.c2.com/?BoyScoutRule))
- [x] The code is readable, comments are added that explain hard or non-obvious parts.
- [x] I've expanded/improved the (unit) tests, when applicable
- [x] I've run (unit) tests that prove my solution works
- [x] There's no sensitive information like credentials in my PR