### PR TITLE
feat: Change strategy, work per word instead of the whole input string

### DIFF
--- a/internal/search/domain/search.go
+++ b/internal/search/domain/search.go
@@ -1,8 +1,7 @@
 package domain
 
 import (
-	"regexp"
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
 )
@@ -11,6 +10,7 @@ const (
 	VersionParam     = "version"
 	RelevanceParam   = "relevance"
 	DefaultRelevance = 0.5
+	Wildcard         = ":*"
 )
 
 // GeoJSON properties in search response
@@ -24,18 +24,15 @@ const (
 	PropHref              = "href"
 )
 
-var (
-	// match & (AND), | (OR), ! (NOT), and <-> (FOLLOWED BY).
-	searchOperatorsRegex = regexp.MustCompile(`&|\||!|<->`)
-)
-
+// SearchQuery based on parsed search terms/words.
 type SearchQuery struct {
-	terms []string
+	words           []string
+	withoutSynonyms map[string]struct{}
+	withSynonyms    map[string][]string
 }
 
-func NewSearchQuery(terms []string) SearchQuery {
-	sort.Strings(terms)
-	return SearchQuery{terms: terms}
+func NewSearchQuery(words []string, withoutSynonyms map[string]struct{}, withSynonyms map[string][]string) SearchQuery {
+	return SearchQuery{words, withoutSynonyms, withSynonyms}
 }
 
 func (q *SearchQuery) ToWildcardQuery() string {
@@ -48,25 +45,32 @@ func (q *SearchQuery) ToExactMatchQuery() string {
 
 func (q *SearchQuery) toString(wildcard bool) string {
 	sb := &strings.Builder{}
-	for i, term := range q.terms {
-		// remove user provided search operators
-		term = searchOperatorsRegex.ReplaceAllString(term, "")
-
-		// assemble query
-		sb.WriteByte('(')
-		parts := strings.Fields(term)
-		for j, part := range parts {
-			sb.WriteString(part)
-			if wildcard {
-				sb.WriteString(":*")
-			}
-			if j != len(parts)-1 {
-				sb.WriteString(" & ")
-			}
+	for i, word := range q.words {
+		if i > 0 {
+			sb.WriteString(" & ")
 		}
-		sb.WriteByte(')')
-		if i != len(q.terms)-1 {
-			sb.WriteString(" | ")
+		if _, ok := q.withoutSynonyms[word]; ok {
+			sb.WriteString(word)
+			if wildcard {
+				sb.WriteString(Wildcard)
+			}
+		} else if synonyms, ok := q.withSynonyms[word]; ok {
+			slices.Sort(synonyms)
+			sb.WriteByte('(')
+			sb.WriteString(word)
+			if wildcard {
+				sb.WriteString(Wildcard)
+			}
+			for j, synonym := range synonyms {
+				if j != len(synonym)-1 {
+					sb.WriteString(" | ")
+				}
+				sb.WriteString(synonym)
+				if wildcard {
+					sb.WriteString(Wildcard)
+				}
+			}
+			sb.WriteByte(')')
 		}
 	}
 	return sb.String()

--- a/internal/search/main_test.go
+++ b/internal/search/main_test.go
@@ -85,6 +85,16 @@ func TestSearch(t *testing.T) {
 		want   want
 	}{
 		{
+			name: "Fail on search with boolean operators",
+			fields: fields{
+				url: "http://localhost:8080/search?q=!foo&addresses[version]=1",
+			},
+			want: want{
+				body:       "internal/search/testdata/expected-boolean-operators.json",
+				statusCode: http.StatusBadRequest,
+			},
+		},
+		{
 			name: "Fail on search without collection parameter(s)",
 			fields: fields{
 				url: "http://localhost:8080/search?q=Oudeschild&limit=50",

--- a/internal/search/query_expansion.go
+++ b/internal/search/query_expansion.go
@@ -5,18 +5,11 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"regexp"
 	"slices"
 	"sort"
 	"strings"
 
 	"github.com/PDOK/gomagpie/internal/search/domain"
-)
-
-var (
-	// Regex to remove user provided search operators:
-	// matches & (AND), | (OR), ! (NOT), and <-> (FOLLOWED BY).
-	searchOperatorsRegex = regexp.MustCompile(`&|\||!|<->`)
 )
 
 // QueryExpansion query expansion involves evaluating a user's input (what words were typed into the search query area)
@@ -38,8 +31,7 @@ func NewQueryExpansion(rewritesFile, synonymsFile string) (*QueryExpansion, erro
 
 // Expand Perform query expansion, see https://en.wikipedia.org/wiki/Query_expansion
 func (s QueryExpansion) Expand(searchTerms string) domain.SearchQuery {
-	normalized := searchOperatorsRegex.ReplaceAllString(strings.ToLower(searchTerms), "")
-	rewritten := rewrite(normalized, s.rewrites)
+	rewritten := rewrite(strings.ToLower(searchTerms), s.rewrites)
 	return domain.NewSearchQuery(expandSynonyms(rewritten, s.synonyms))
 }
 

--- a/internal/search/query_expansion.go
+++ b/internal/search/query_expansion.go
@@ -181,12 +181,19 @@ func readCsvFile(filepath string, bidi bool) (map[string][]string, error) {
 
 	result := make(map[string][]string)
 	for _, row := range records {
-		key := strings.ToLower(row[0])
-		result[key] = make([]string, 0)
+		key, err := assertSynonymLength(strings.ToLower(row[0]))
+		if err != nil {
+			return nil, err
+		}
 
 		// add all alternatives
+		result[key] = make([]string, 0)
 		for i := 1; i < len(row); i++ {
-			result[key] = append(result[key], strings.ToLower(row[i]))
+			val, err := assertSynonymLength(strings.ToLower(row[i]))
+			if err != nil {
+				return nil, err
+			}
+			result[key] = append(result[key], val)
 		}
 
 		if bidi {
@@ -208,4 +215,11 @@ func readCsvFile(filepath string, bidi bool) (map[string][]string, error) {
 		}
 	}
 	return result, nil
+}
+
+func assertSynonymLength(syn string) (string, error) {
+	if len(syn) < 2 {
+		return "", fmt.Errorf("failed to parse CSV file: synonym '%s' is too short, should be at least 2 chars long", syn)
+	}
+	return syn, nil
 }

--- a/internal/search/query_expansion_fuzz_test.go
+++ b/internal/search/query_expansion_fuzz_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path"
 	"runtime"
+	"strings"
 	"testing"
 	"unicode/utf8"
 
@@ -34,6 +35,8 @@ func FuzzExpand(f *testing.F) {
 		query := expanded.ToExactMatchQuery()
 
 		assert.Truef(t, utf8.ValidString(query), "valid string")
-		assert.NotEmpty(t, query)
+		if strings.TrimSpace(input) != "" {
+			assert.NotEmpty(t, query)
+		}
 	})
 }

--- a/internal/search/query_expansion_test.go
+++ b/internal/search/query_expansion_test.go
@@ -37,13 +37,6 @@ func TestExpand(t *testing.T) {
 			want: `spui & 1 & gravenhage`,
 		},
 		{
-			name: "remove user provided search operators",
-			args: args{
-				searchQuery: `A & B !C D <-> E`,
-			},
-			want: `a & b & c & d & e`,
-		},
-		{
 			name: "no synonym",
 			args: args{
 				searchQuery: `just some text`,
@@ -79,12 +72,10 @@ func TestExpand(t *testing.T) {
 			want: `
 (oudwesterlijke-goeverneur | oudewestelijkelijke-goev | oudewestelijkelijke-goeverneur | oudewestelijkelijke-gouv | 
 oudewestelijkelijke-gouverneur | oudewesterlijke-goev | oudewesterlijke-goeverneur | oudewesterlijke-gouv | 
-oudewesterlijke-gouverneur | oudewestlijke-goev | oudewestlijke-goeverneur | oudewestlijke-gouv | 
-oudewestlijke-gouverneur | oudewlijke-goev | oudewlijke-goeverneuroudewlijke-gouv | oudewlijke-gouverneur | 
+oudewesterlijke-gouverneur | oudewestlijke-goev | oudewestlijke-goeverneur | oudewestlijke-gouv | oudewestlijke-gouverneur | 
 oudwestelijkelijke-goev | oudwestelijkelijke-goeverneur | oudwestelijkelijke-gouv | oudwestelijkelijke-gouverneur | 
 oudwesterlijke-goev | oudwesterlijke-gouv | oudwesterlijke-gouverneur | oudwestlijke-goev | 
-oudwestlijke-goeverneur | oudwestlijke-gouv | oudwestlijke-gouverneur | oudwlijke-goev | 
-oudwlijke-goeverneur | oudwlijke-gouv | oudwlijke-gouverneur)
+oudwestlijke-goeverneur | oudwestlijke-gouvoudwestlijke-gouverneur)
 `,
 		},
 		{
@@ -113,7 +104,7 @@ oudwlijke-goeverneur | oudwlijke-gouv | oudwlijke-gouverneur)
 			args: args{
 				searchQuery: `ok text with spaces ok`,
 			},
-			want: `ok & text & (with | westelijkeith | westerith | westith) & spaces`,
+			want: `ok & text & with & spaces`,
 		},
 		{
 			name: "long",
@@ -148,9 +139,8 @@ piet & (gouverneurstraat | goeverneurstraat | goevstraat | gouvstraat) & 1800
 			want: `
 (oude | oud) & piet & 
 (westgouverneurstraat | westelijkegoeverneurstraat | westelijkegoevstraat | westelijkegouverneurstraat | 
-westelijkegouvstraat | westergoeverneurstraat | westergoevstraat | westergouverneurstraat | 
-westergouvstraat | westgoeverneurstraat | westgoevstraat | westgouvstraat | wgoeverneurstraat | 
-wgoevstraat | wgouverneurstraat | wgouvstraat) & 1800
+westelijkegouvstraat | westergoeverneurstraat | westergoevstraat | westergouverneurstraat | westergouvstraat | 
+westgoeverneurstraat | westgoevstraat | westgouvstraat) & 1800
 `,
 		},
 		{
@@ -163,7 +153,7 @@ wgoevstraat | wgouverneurstraat | wgouvstraat) & 1800
 `,
 		},
 		{
-			name: "lots of synonyms",
+			name: "four synonyms",
 			args: args{
 				searchQuery: `Oud Gouv 2DE 's-Gravenhage Fryslân Nederland`,
 			},

--- a/internal/search/query_expansion_test.go
+++ b/internal/search/query_expansion_test.go
@@ -34,121 +34,123 @@ func TestExpand(t *testing.T) {
 			args: args{
 				searchQuery: `Spui 1 den Haag`,
 			},
-			want: `(spui & 1 & gravenhage)`,
+			want: `spui & 1 & gravenhage`,
 		},
 		{
 			name: "remove user provided search operators",
 			args: args{
 				searchQuery: `A & B !C D <-> E`,
 			},
-			want: `(a & b & c & d & e)`,
+			want: `a & b & c & d & e`,
 		},
 		{
 			name: "no synonym",
 			args: args{
 				searchQuery: `just some text`,
 			},
-			want: `(just & some & text)`,
+			want: `just & some & text`,
 		},
 		{
 			name: "one synonym",
 			args: args{
 				searchQuery: `Foo`,
 			},
-			want: `(foo) | (foobar) | (foos)`,
+			want: `(foo | foobar | foos)`,
 		},
 		{
 			name: "two the same synonyms",
 			args: args{
 				searchQuery: `Foo FooBar`,
 			},
-			want: `(foo & foo) | (foo & foobar) | (foo & foos) | (foobar & foo) | (foobar & foobar) | (foobar & foos) | (foos & foo) | (foos & foobar) | (foos & foos)`,
+			want: `(foo | foobar | foos) & (foobar | foo | foos)`,
 		},
 		{
 			name: "two-way synonym",
 			args: args{
 				searchQuery: `eerste 2de`,
 			},
-			want: `(1ste & 2de) | (1ste & tweede) | (eerste & 2de) | (eerste & tweede)`,
+			want: `(eerste | 1ste) & (2de | tweede)`,
+		},
+		{
+			name: "nesting",
+			args: args{
+				searchQuery: `oudwesterlijke-goeverneur`,
+			},
+			want: `
+(oudwesterlijke-goeverneur | oudewestelijkelijke-goev | oudewestelijkelijke-goeverneur | oudewestelijkelijke-gouv | 
+oudewestelijkelijke-gouverneur | oudewesterlijke-goev | oudewesterlijke-goeverneur | oudewesterlijke-gouv | 
+oudewesterlijke-gouverneur | oudewestlijke-goev | oudewestlijke-goeverneur | oudewestlijke-gouv | 
+oudewestlijke-gouverneur | oudewlijke-goev | oudewlijke-goeverneuroudewlijke-gouv | oudewlijke-gouverneur | 
+oudwestelijkelijke-goev | oudwestelijkelijke-goeverneur | oudwestelijkelijke-gouv | oudwestelijkelijke-gouverneur | 
+oudwesterlijke-goev | oudwesterlijke-gouv | oudwesterlijke-gouverneur | oudwestlijke-goev | 
+oudwestlijke-goeverneur | oudwestlijke-gouv | oudwestlijke-gouverneur | oudwlijke-goev | 
+oudwlijke-goeverneur | oudwlijke-gouv | oudwlijke-gouverneur)
+`,
 		},
 		{
 			name: "overlapping synonyms",
 			args: args{
 				searchQuery: `foosball`,
 			},
-			want: `(fooball) | (foobarball) | (foosball)`,
+			want: `(foosball | fooball | foobarball)`,
 		},
 		{
 			name: "synonym with diacritics",
 			args: args{
 				searchQuery: `oude fryslân`,
 			},
-			want: `(oud & friesland) | (oud & fryslân) | (oude & friesland) | (oude & fryslân)`,
+			want: `(oude | oud) & (fryslân | friesland)`,
 		},
 		{
 			name: "case insensitive",
 			args: args{
 				searchQuery: `OudE DeN HaAg`,
 			},
-			want: `(oud & gravenhage) | (oude & gravenhage)`,
+			want: `(oude | oud) & gravenhage`,
 		},
 		{
 			name: "word delimiters",
 			args: args{
 				searchQuery: `ok text with spaces ok`,
 			},
-			want: `(ok & text & with & spaces & ok) | (ok & text-with-delims & ok) | (ok & textwithoutspaces & ok)`,
+			want: `ok & text & (with | westelijkeith | westerith | westith) & spaces`,
+		},
+		{
+			name: "long",
+			args: args{
+				searchQuery: `prof dr ir van der 1e noordsteeg`,
+			},
+			want: `prof & dr & ir & van & der & 1e & noordsteeg`,
 		},
 		{
 			name: "one substring",
 			args: args{
-				searchQuery: `1e Gouverneurstraat 1800`,
+				searchQuery: `Piet Gouverneurstraat 1800`,
 			},
 			want: `
-(1e & goeverneurstraat & 1800) | 
-(1e & goevstraat & 1800) | 
-(1e & gouverneurstraat & 1800) | 
-(1e & gouvstraat & 1800)
+piet & (gouverneurstraat | goeverneurstraat | goevstraat | gouvstraat) & 1800
+`,
+		},
+		{
+			name: "two substrings",
+			args: args{
+				searchQuery: `Oude Piet Gouverneurstraat 1800`,
+			},
+			want: `
+(oude | oud) & piet & (gouverneurstraat | goeverneurstraat | goevstraat | gouvstraat) & 1800
 `,
 		},
 		{
 			name: "three substrings",
 			args: args{
-				searchQuery: `Oude Westelijker-Gouverneurstraat`,
+				searchQuery: `Oude Piet Westgouverneurstraat 1800`,
 			},
 			want: `
-(oud & westelijker-goeverneurstraat) | 
-(oud & westelijker-goevstraat) | 
-(oud & westelijker-gouverneurstraat) | 
-(oud & westelijker-gouvstraat) | 
-(oud & westerr-goeverneurstraat) | 
-(oud & westerr-goevstraat) | 
-(oud & westerr-gouverneurstraat) | 
-(oud & westerr-gouvstraat) | 
-(oud & westr-goeverneurstraat) | 
-(oud & westr-goevstraat) | 
-(oud & westr-gouverneurstraat) | 
-(oud & westr-gouvstraat) | 
-(oud & wr-goeverneurstraat) | 
-(oud & wr-goevstraat) | 
-(oud & wr-gouverneurstraat) | 
-(oud & wr-gouvstraat) | 
-(oude & westelijker-goeverneurstraat) | 
-(oude & westelijker-goevstraat) | 
-(oude & westelijker-gouverneurstraat) | 
-(oude & westelijker-gouvstraat) | 
-(oude & westerr-goeverneurstraat) | 
-(oude & westerr-goevstraat) | 
-(oude & westerr-gouverneurstraat) | 
-(oude & westerr-gouvstraat) | 
-(oude & westr-goeverneurstraat) | 
-(oude & westr-goevstraat) | 
-(oude & westr-gouverneurstraat) | 
-(oude & westr-gouvstraat) | 
-(oude & wr-goeverneurstraat) | 
-(oude & wr-goevstraat) | 
-(oude & wr-gouverneurstraat) | 
-(oude & wr-gouvstraat)
+(oude | oud) & piet & 
+(westgouverneurstraat | westelijkegoeverneurstraat | westelijkegoevstraat | westelijkegouverneurstraat | 
+westelijkegouvstraat | westergoeverneurstraat | westergoevstraat | westergouverneurstraat | 
+westergouvstraat | westgoeverneurstraat | westgoevstraat | westgouvstraat | wgoeverneurstraat | 
+wgoevstraat | wgouverneurstraat | wgouvstraat) & 1800
 `,
 		},
 		{
@@ -157,14 +159,7 @@ func TestExpand(t *testing.T) {
 				searchQuery: `goev straat 1 in Den Haag niet in Friesland`,
 			},
 			want: `
-(goev & straat & 1 & in & gravenhage & niet & in & friesland) | 
-(goev & straat & 1 & in & gravenhage & niet & in & fryslân) | 
-(goeverneur & straat & 1 & in & gravenhage & niet & in & friesland) | 
-(goeverneur & straat & 1 & in & gravenhage & niet & in & fryslân) | 
-(gouv & straat & 1 & in & gravenhage & niet & in & friesland) | 
-(gouv & straat & 1 & in & gravenhage & niet & in & fryslân) | 
-(gouverneur & straat & 1 & in & gravenhage & niet & in & friesland) | 
-(gouverneur & straat & 1 & in & gravenhage & niet & in & fryslân)
+(goev | goeverneur | gouv | gouverneur) & straat & 1 & in & gravenhage & niet & (friesland | fryslân)
 `,
 		},
 		{
@@ -173,38 +168,7 @@ func TestExpand(t *testing.T) {
 				searchQuery: `Oud Gouv 2DE 's-Gravenhage Fryslân Nederland`,
 			},
 			want: `
-(oud & goev & 2de & gravenhage & friesland & nederland) | 
-(oud & goev & 2de & gravenhage & fryslân & nederland) | 
-(oud & goev & tweede & gravenhage & friesland & nederland) | 
-(oud & goev & tweede & gravenhage & fryslân & nederland) | 
-(oud & goeverneur & 2de & gravenhage & friesland & nederland) | 
-(oud & goeverneur & 2de & gravenhage & fryslân & nederland) | 
-(oud & goeverneur & tweede & gravenhage & friesland & nederland) | 
-(oud & goeverneur & tweede & gravenhage & fryslân & nederland) | 
-(oud & gouv & 2de & gravenhage & friesland & nederland) | 
-(oud & gouv & 2de & gravenhage & fryslân & nederland) | 
-(oud & gouv & tweede & gravenhage & friesland & nederland) | 
-(oud & gouv & tweede & gravenhage & fryslân & nederland) | 
-(oud & gouverneur & 2de & gravenhage & friesland & nederland) | 
-(oud & gouverneur & 2de & gravenhage & fryslân & nederland) | 
-(oud & gouverneur & tweede & gravenhage & friesland & nederland) | 
-(oud & gouverneur & tweede & gravenhage & fryslân & nederland) | 
-(oude & goev & 2de & gravenhage & friesland & nederland) | 
-(oude & goev & 2de & gravenhage & fryslân & nederland) | 
-(oude & goev & tweede & gravenhage & friesland & nederland) | 
-(oude & goev & tweede & gravenhage & fryslân & nederland) | 
-(oude & goeverneur & 2de & gravenhage & friesland & nederland) | 
-(oude & goeverneur & 2de & gravenhage & fryslân & nederland) | 
-(oude & goeverneur & tweede & gravenhage & friesland & nederland) | 
-(oude & goeverneur & tweede & gravenhage & fryslân & nederland) | 
-(oude & gouv & 2de & gravenhage & friesland & nederland) | 
-(oude & gouv & 2de & gravenhage & fryslân & nederland) | 
-(oude & gouv & tweede & gravenhage & friesland & nederland) | 
-(oude & gouv & tweede & gravenhage & fryslân & nederland) | 
-(oude & gouverneur & 2de & gravenhage & friesland & nederland) | 
-(oude & gouverneur & 2de & gravenhage & fryslân & nederland) | 
-(oude & gouverneur & tweede & gravenhage & friesland & nederland) | 
-(oude & gouverneur & tweede & gravenhage & fryslân & nederland)
+(oud | oude) & (gouv | goev | goeverneur | gouverneur) & (2de | tweede) & gravenhage & (fryslân | friesland) & nederland
 `,
 		},
 	}

--- a/internal/search/testdata/expected-boolean-operators.json
+++ b/internal/search/testdata/expected-boolean-operators.json
@@ -1,0 +1,6 @@
+{
+  "detail": "provided search terms contain one ore more boolean operators such as \u0026 (AND), | (OR), ! (NOT) which aren't allowed",
+  "status": 400,
+  "timeStamp": "2000-01-01T00:00:00Z",
+  "title": "Bad Request"
+}

--- a/internal/search/testdata/synonyms.csv
+++ b/internal/search/testdata/synonyms.csv
@@ -6,5 +6,5 @@ Friesland,fryslân
 goeverneur,goev,gouverneur,gouv
 foo,foos,Foobar
 oud,oude
-west,westelijke,wester,w
+west,westelijke,wester
 text with spaces,textwithoutspaces,text-with-delims

--- a/internal/search/url.go
+++ b/internal/search/url.go
@@ -23,6 +23,9 @@ const (
 
 var (
 	deepObjectParamRegex = regexp.MustCompile(`\w+\[\w+]`)
+
+	// matches & (AND), | (OR), ! (NOT), and <-> (FOLLOWED BY).
+	searchOperatorsRegex = regexp.MustCompile(`&|\||!|<->`)
 )
 
 func parseQueryParams(query url.Values) (collections d.CollectionsWithParams, searchTerms string, outputSRID d.SRID, limit int, err error) {
@@ -66,12 +69,16 @@ func parseCollections(query url.Values) (d.CollectionsWithParams, error) {
 	return deepObjectParams, nil
 }
 
-func parseSearchTerms(query url.Values) (searchTerms string, err error) {
-	searchTerms = query.Get(queryParam)
+func parseSearchTerms(query url.Values) (string, error) {
+	searchTerms := strings.TrimSpace(strings.ToLower(query.Get(queryParam)))
 	if searchTerms == "" {
-		err = fmt.Errorf("no search terms provided, '%s' query parameter is required", queryParam)
+		return "", fmt.Errorf("no search terms provided, '%s' query parameter is required", queryParam)
 	}
-	return
+	if searchOperatorsRegex.MatchString(searchTerms) {
+		return "", errors.New("provided search terms contain one ore more boolean operators " +
+			"such as & (AND), | (OR), ! (NOT) which aren't allowed")
+	}
+	return searchTerms, nil
 }
 
 // implements req 7.6 (https://docs.ogc.org/is/17-069r4/17-069r4.html#query_parameters)


### PR DESCRIPTION
# Description

Change strategy, instead of working on the whole input string, work on the individual words. To prevent too complex search queries / too many combinations.

## Type of change

- Improvement of existing feature

# Checklist:

- [x] I've double-checked the code in this PR myself
- [ ] I've left the code better than before ([boy scout rule](https://wiki.c2.com/?BoyScoutRule))
- [ ] The code is readable, comments are added that explain hard or non-obvious parts.
- [ ] I've expanded/improved the (unit) tests, when applicable
- [ ] I've run (unit) tests that prove my solution works
- [ ] There's no sensitive information like credentials in my PR