### PR TITLE
fix(search): correct bbox output in features

### DIFF
--- a/internal/engine/templates/openapi/features-search.go.json
+++ b/internal/engine/templates/openapi/features-search.go.json
@@ -78,6 +78,9 @@
                           "..."
                         ]
                       },
+                      "bbox": [
+                        "..."
+                      ],
                       "properties": {
                         "function": "residential",
                         "floors": "2",
@@ -93,6 +96,7 @@
                           "..."
                         ]
                       },
+                      "bbox": null,
                       "properties": {
                         "function": "public use",
                         "floors": "10",
@@ -133,12 +137,15 @@
                       "type": "Feature",
                       "id": "123",
                       "place": {
-                        "type": "Polygon",
+                        "type": "Point",
                         "coordinates": [
                           "..."
                         ]
                       },
                       "geometry": null,
+                      "bbox": [
+                        "..."
+                      ],
                       "time": null,
                       "properties": {
                         "function": "residential",
@@ -150,12 +157,13 @@
                       "type": "Feature",
                       "id": "132",
                       "place": {
-                        "type": "Polygon",
+                        "type": "Point",
                         "coordinates": [
                           "..."
                         ]
                       },
                       "geometry": null,
+                      "bbox": null,
                       "time": null,
                       "properties": {
                         "function": "public use",
@@ -263,6 +271,7 @@
             "time",
             "place",
             "geometry",
+            "bbox",
             "properties",
             "type"
         ],
@@ -308,6 +317,15 @@
               }
             ]
           },
+          "bbox": {
+            "type": "array",
+            "nullable": true,
+            "minItems": 4,
+            "maxItems": 4,
+            "items": {
+              "type": "number"
+            }
+          },
           "properties": {
             "type": "object",
             "nullable": true
@@ -333,6 +351,7 @@
       "featureGeoJSON": {
         "required": [
           "geometry",
+          "bbox",
           "properties",
           "type"
         ],
@@ -346,6 +365,15 @@
           },
           "geometry": {
             "$ref": "#/components/schemas/geometryGeoJSON"
+          },
+          "bbox": {
+            "type": "array",
+            "nullable": true,
+            "minItems": 4,
+            "maxItems": 4,
+            "items": {
+              "type": "number"
+            }
           },
           "properties": {
             "type": "object",

--- a/internal/search/domain/geojson.go
+++ b/internal/search/domain/geojson.go
@@ -34,7 +34,7 @@ type Feature struct {
 	Type       featureType       `json:"type"`
 	Properties map[string]any    `json:"properties"`
 	Geometry   *geojson.Geometry `json:"geometry"`
-	Bbox       *geojson.Geometry `json:"bbox"`
+	Bbox       *[]float64        `json:"bbox"`
 	// We expect feature ids to be auto-incrementing integers (which is the default in geopackages)
 	// since we use it for cursor-based pagination.
 	ID    string `json:"id"`


### PR DESCRIPTION
# Description

As per GeoJSON spec, the `bbox` property must be returned as an array. For features where the collection geometry type is `POINT`, the `bbox` property is returned as `null`.

## Type of change

- Improvement of existing feature
- Bugfix

# Checklist:

- [x] I've double-checked the code in this PR myself
- [x] I've left the code better than before ([boy scout rule](https://wiki.c2.com/?BoyScoutRule))
- [x] The code is readable, comments are added that explain hard or non-obvious parts.
- [x] I've expanded/improved the (unit) tests, when applicable
- [x] I've run (unit) tests that prove my solution works
- [x] There's no sensitive information like credentials in my PR