### PR TITLE
feat(search): add bbox parameters

### DIFF
--- a/internal/engine/templates/openapi/features-search.go.json
+++ b/internal/engine/templates/openapi/features-search.go.json
@@ -673,6 +673,59 @@
       }
       {{- end -}}
       ,
+      "bbox": {
+        "name": "bbox",
+        "in": "query",
+        "description": "Only features that have a geometry that intersects the bounding box are selected.\nThe bounding box is provided as four numbers\n* Lower left corner, coordinate axis 1\n* Lower left corner, coordinate axis 2\n* Upper right corner, coordinate axis 1\n* Upper right corner, coordinate axis 2\n\nThe coordinate reference system is\nWGS 84 longitude/latitude (http://www.opengis.net/def/crs/OGC/1.3/CRS84)\nunless a different coordinate reference system is specified in the parameter `bbox-crs`.\n\nThe query parameter `bbox-crs` is specified in OGC API - Features - Part 2: Coordinate\nReference Systems by Reference.\n\nFor WGS 84 longitude/latitude the values are in most cases the sequence of\nminimum longitude, minimum latitude, maximum longitude and maximum latitude.\nHowever, in cases where the box spans the antimeridian the first value\n(west-most box edge) is larger than the third value (east-most box edge).\n\nIf a feature has multiple spatial geometry properties, it is the decision of the\nserver whether only a single spatial geometry property is used to determine\nthe extent or all relevant geometries.\nThe given coordinates should be separated by commas.",
+        "required": false,
+        "style": "form",
+        "explode": false,
+        "schema": {
+          "type": "array",
+          "minItems": 4,
+          "maxItems": 6,
+          "items": {
+            "type": "number"
+          }
+        }
+{{/* Replace schema with the following once https://github.com/opengeospatial/ets-ogcapi-features10/issues/223 is fixed*/}}
+{{/* */}}
+{{/*        "schema": {*/}}
+{{/*          "type": "array",*/}}
+{{/*          "oneOf": [*/}}
+{{/*            {*/}}
+{{/*              "maxItems": 4,*/}}
+{{/*              "minItems": 4*/}}
+{{/*            },*/}}
+{{/*            {*/}}
+{{/*              "maxItems": 6,*/}}
+{{/*              "minItems": 6*/}}
+{{/*            }*/}}
+{{/*          ],*/}}
+{{/*          "items": {*/}}
+{{/*            "type": "number",*/}}
+{{/*            "format": "double"*/}}
+{{/*          }*/}}
+{{/*        }*/}}
+      },
+      "bbox-crs": {
+        "name": "bbox-crs",
+        "in": "query",
+        "description": "The coordinate reference system of the `bbox` parameter. Default is WGS84 longitude/latitude.",
+        "required": false,
+        "schema": {
+          "type": "string",
+          "format": "uri",
+          "default": "http://www.opengis.net/def/crs/OGC/1.3/CRS84",
+          "enum": [
+            {{/* TODO make configurable */}}
+            "http://www.opengis.net/def/crs/OGC/1.3/CRS84",
+            "http://www.opengis.net/def/crs/EPSG/0/28992"
+          ]
+        },
+        "style": "form",
+        "explode": false
+      },
       "crs": {
         "name": "crs",
         "in": "query",

--- a/internal/engine/util/area.go
+++ b/internal/engine/util/area.go
@@ -1,0 +1,14 @@
+package util
+
+import (
+	"math"
+
+	"github.com/twpayne/go-geom"
+)
+
+// Copied from https://github.com/PDOK/gokoala/blob/070ec77b2249553959330ff8029bfdf48d7e5d86/internal/ogc/features/url.go#L264
+func SurfaceArea(bbox *geom.Bounds) float64 {
+	// Use the same logic as bbox.Area() in https://github.com/go-spatial/geom to calculate surface area.
+	// The bounds.Area() in github.com/twpayne/go-geom behaves differently and is not what we're looking for.
+	return math.Abs((bbox.Max(1) - bbox.Min(1)) * (bbox.Max(0) - bbox.Min(0)))
+}

--- a/internal/engine/util/area_test.go
+++ b/internal/engine/util/area_test.go
@@ -1,0 +1,33 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/twpayne/go-geom"
+)
+
+func TestSurfaceArea(t *testing.T) {
+	tests := []struct {
+		name string
+		bbox *geom.Bounds
+		want float64
+	}{
+		{
+			name: "Test correct bbox",
+			bbox: geom.NewBounds(geom.XY).Set(0.0, 0.0, 5.0, 5.0),
+			want: 25.0,
+		},
+		{
+			name: "Test bbox with zero area",
+			bbox: geom.NewBounds(geom.XY).Set(0.0, 5.0, 0.0, 5.0),
+			want: 0.0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := SurfaceArea(tt.bbox)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/internal/etl/load/postgres.go
+++ b/internal/etl/load/postgres.go
@@ -125,6 +125,18 @@ func (p *Postgres) Init(index string, lang language.Tag) error {
 		return fmt.Errorf("error creating GIN index: %w", err)
 	}
 
+	// GIST indexes for bbox and geometry columns, to support search within a bounding box
+	geometryIndex := fmt.Sprintf(`create index if not exists geometry_idx on %[1]s using gist(geometry);`, index)
+	_, err = p.db.Exec(p.ctx, geometryIndex)
+	if err != nil {
+		return fmt.Errorf("error creating GIST index: %w", err)
+	}
+	bboxIndex := fmt.Sprintf(`create index if not exists bbox_idx on %[1]s using gist(bbox);`, index)
+	_, err = p.db.Exec(p.ctx, bboxIndex)
+	if err != nil {
+		return fmt.Errorf("error creating GIST index: %w", err)
+	}
+
 	// create custom collation to correctly handle "numbers in strings" when sorting results
 	// see https://www.postgresql.org/docs/12/collation.html#id-1.6.10.4.5.7.5
 	collation := fmt.Sprintf(`create collation if not exists custom_numeric (provider = icu, locale = '%s-u-kn-true');`, lang.String())

--- a/internal/etl/transform/transform.go
+++ b/internal/etl/transform/transform.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"math"
 	"slices"
 	"strconv"
 	"strings"
@@ -12,6 +11,7 @@ import (
 
 	"github.com/PDOK/gomagpie/config"
 	"github.com/PDOK/gomagpie/internal/engine"
+	"github.com/PDOK/gomagpie/internal/engine/util"
 	"github.com/google/uuid"
 	"github.com/twpayne/go-geom"
 )
@@ -116,17 +116,10 @@ func (r RawRecord) transformBbox() (*geom.Polygon, error) {
 	if strings.EqualFold(r.GeometryType, "POINT") {
 		return nil, nil // No bbox for point geometries
 	}
-	if surfaceArea(r.Bbox) <= 0 {
+	if util.SurfaceArea(r.Bbox) <= 0 {
 		return nil, errors.New("bbox area must be greater than zero")
 	}
 	return r.Bbox.Polygon().SetSRID(WGS84), nil
-}
-
-// Copied from https://github.com/PDOK/gokoala/blob/070ec77b2249553959330ff8029bfdf48d7e5d86/internal/ogc/features/url.go#L264
-func surfaceArea(bbox *geom.Bounds) float64 {
-	// Use the same logic as bbox.Area() in https://github.com/go-spatial/geom to calculate surface area.
-	// The bounds.Area() in github.com/twpayne/go-geom behaves differently and is not what we're looking for.
-	return math.Abs((bbox.Max(1) - bbox.Min(1)) * (bbox.Max(0) - bbox.Min(0)))
 }
 
 func slicesToStringMap(keys []string, values []any) (map[string]string, error) {

--- a/internal/search/datasources/datasource.go
+++ b/internal/search/datasources/datasource.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/PDOK/gomagpie/internal/search/domain"
+	"github.com/twpayne/go-geom"
 )
 
 // Datasource knows how make different kinds of queries/actions on the underlying actual datastore.
@@ -12,7 +13,7 @@ type Datasource interface {
 	// SearchFeaturesAcrossCollections search features in one or more collections. Collections can be located
 	// in this dataset or in other datasets.
 	SearchFeaturesAcrossCollections(ctx context.Context, searchQuery domain.SearchQuery,
-		collections domain.CollectionsWithParams, srid domain.SRID, limit int) (*domain.FeatureCollection, error)
+		collections domain.CollectionsWithParams, srid domain.SRID, bbox *geom.Bounds, bboxSRID domain.SRID, limit int) (*domain.FeatureCollection, error)
 
 	// Close closes (connections to) the datasource gracefully
 	Close()

--- a/internal/search/datasources/postgres/postgres.go
+++ b/internal/search/datasources/postgres/postgres.go
@@ -225,11 +225,11 @@ func parseBbox(bbox *geom.Bounds, bboxSRID d.SRID) (string, []any, error) {
 	if bbox != nil {
 		if bboxSRID != d.WGS84SRIDPostgis {
 			bboxFilter = `AND
-				(st_intersects(st_transform(r.geometry, $8::int), st_geomfromtext($7::text, $8::int)) OR st_intersects(st_transform(r.bbox, $8::int), st_geomfromtext($7::text, $8::int)))
+				(st_intersects(st_transform(r.geometry, $13::int), st_geomfromtext($12::text, $13::int)) OR st_intersects(st_transform(r.bbox, $13::int), st_geomfromtext($12::text, $13::int)))
 			`
 		} else {
 			bboxFilter = `AND
-				(st_intersects(r.geometry, st_geomfromtext($7::text, $8::int)) OR st_intersects(r.bbox, st_geomfromtext($7::text, $8::int)))
+				(st_intersects(r.geometry, st_geomfromtext($12::text, $13::int)) OR st_intersects(r.bbox, st_geomfromtext($12::text, $13::int)))
 			`
 		}
 		bboxWkt, err = wkt.Marshal(bbox.Polygon())

--- a/internal/search/datasources/postgres/postgres.go
+++ b/internal/search/datasources/postgres/postgres.go
@@ -3,6 +3,7 @@ package postgres
 import (
 	"context"
 	"fmt"
+	"log"
 
 	d "github.com/PDOK/gomagpie/internal/search/domain"
 	"github.com/jackc/pgx/v5"
@@ -45,12 +46,12 @@ func (p *Postgres) Close() {
 }
 
 func (p *Postgres) SearchFeaturesAcrossCollections(ctx context.Context, searchQuery d.SearchQuery,
-	collections d.CollectionsWithParams, srid d.SRID, limit int) (*d.FeatureCollection, error) {
+	collections d.CollectionsWithParams, srid d.SRID, bbox *geom.Bounds, bboxSRID d.SRID, limit int) (*d.FeatureCollection, error) {
 
 	queryCtx, cancel := context.WithTimeout(ctx, p.queryTimeout)
 	defer cancel()
 
-	sql := makeSQL(p.searchIndex, srid)
+	sql := makeSQL(p.searchIndex, srid, bbox, bboxSRID)
 	wildcardQuery := searchQuery.ToWildcardQuery()
 	exactMatchQuery := searchQuery.ToExactMatchQuery()
 	names, versions, relevance := collections.NamesAndVersionsAndRelevance()
@@ -67,7 +68,8 @@ func (p *Postgres) SearchFeaturesAcrossCollections(ctx context.Context, searchQu
 }
 
 //nolint:funlen
-func makeSQL(index string, srid d.SRID) string {
+func makeSQL(index string, srid d.SRID, bbox *geom.Bounds, bboxSRID d.SRID) string {
+	log.Printf("TODO: query on bbox (%v/%d)\n", bbox, bboxSRID)
 	// language=postgresql
 	return fmt.Sprintf(`
 	WITH query_wildcard AS (

--- a/internal/search/main.go
+++ b/internal/search/main.go
@@ -48,14 +48,14 @@ func (s *Search) Search() http.HandlerFunc {
 			engine.RenderProblem(engine.ProblemBadRequest, w, err.Error())
 			return
 		}
-		collections, searchTerms, outputSRID, limit, err := parseQueryParams(r.URL.Query())
+		collections, searchTerms, outputSRID, bbox, bboxSRID, limit, err := parseQueryParams(r.URL.Query())
 		if err != nil {
 			engine.RenderProblem(engine.ProblemBadRequest, w, err.Error())
 			return
 		}
 
 		fc, err := s.datasource.SearchFeaturesAcrossCollections(r.Context(),
-			s.queryExpansion.Expand(searchTerms), collections, outputSRID, limit)
+			s.queryExpansion.Expand(searchTerms), collections, outputSRID, bbox, bboxSRID, limit)
 		if err != nil {
 			handleQueryError(w, err)
 			return

--- a/internal/search/main_test.go
+++ b/internal/search/main_test.go
@@ -137,7 +137,7 @@ func TestSearch(t *testing.T) {
 		{
 			name: "Search: 'Den' for a single collection in WGS84 (default) with bounding box in WGS84",
 			fields: fields{
-				url: "http://localhost:8080/search?q=Den&addresses[version]=1&addresses[relevance]=0.8&limit=10&bbox=4.219647007921636%2C52.047054413744746%2C4.257020156762858%2C52.0618201177098&f=json",
+				url: "http://localhost:8080/search?q=Den&addresses[version]=1&addresses[relevance]=0.8&limit=10&bbox=4.2888981083359194%2C52.74465818263613%2C5.571330972812564%2C53.391238307109006&f=json",
 			},
 			want: want{
 				body:       "internal/search/testdata/expected-search-den-single-collection-wgs84.json",
@@ -147,7 +147,7 @@ func TestSearch(t *testing.T) {
 		{
 			name: "Search: 'Den' for a single collection in WGS84 (default) with bounding box in RD",
 			fields: fields{
-				url: "http://localhost:8080/search?q=Den&addresses[version]=1&addresses[relevance]=0.8&limit=10&bbox=120379.69%2C566718.72%2C120396.30%2C566734.62&bbox-crs=http%3A%2F%2Fwww.opengis.net%2Fdef%2Fcrs%2FEPSG%2F0%2F28992&f=json",
+				url: "http://localhost:8080/search?q=Den&addresses[version]=1&addresses[relevance]=0.8&limit=10&bbox=108379.69%2C558718.72%2C120396.30%2C566734.62&bbox-crs=http%3A%2F%2Fwww.opengis.net%2Fdef%2Fcrs%2FEPSG%2F0%2F28992&f=json",
 			},
 			want: want{
 				body:       "internal/search/testdata/expected-search-den-single-collection-wgs84.json",

--- a/internal/search/main_test.go
+++ b/internal/search/main_test.go
@@ -135,6 +135,26 @@ func TestSearch(t *testing.T) {
 			},
 		},
 		{
+			name: "Search: 'Den' for a single collection in WGS84 (default) with bounding box in WGS84",
+			fields: fields{
+				url: "http://localhost:8080/search?q=Den&addresses[version]=1&addresses[relevance]=0.8&limit=10&bbox=4.219647007921636%2C52.047054413744746%2C4.257020156762858%2C52.0618201177098&f=json",
+			},
+			want: want{
+				body:       "internal/search/testdata/expected-search-den-single-collection-wgs84.json",
+				statusCode: http.StatusOK,
+			},
+		},
+		{
+			name: "Search: 'Den' for a single collection in WGS84 (default) with bounding box in RD",
+			fields: fields{
+				url: "http://localhost:8080/search?q=Den&addresses[version]=1&addresses[relevance]=0.8&limit=10&bbox=120379.69%2C566718.72%2C120396.30%2C566734.62&bbox-crs=http%3A%2F%2Fwww.opengis.net%2Fdef%2Fcrs%2FEPSG%2F0%2F28992&f=json",
+			},
+			want: want{
+				body:       "internal/search/testdata/expected-search-den-single-collection-wgs84.json",
+				statusCode: http.StatusOK,
+			},
+		},
+		{
 			name: "Search: 'Den' for a single collection in RD",
 			fields: fields{
 				url: "http://localhost:8080/search?q=Den&addresses[version]=1&addresses[relevance]=0.8&limit=10&f=json&crs=http%3A%2F%2Fwww.opengis.net%2Fdef%2Fcrs%2FEPSG%2F0%2F28992",

--- a/internal/search/url.go
+++ b/internal/search/url.go
@@ -87,6 +87,8 @@ func validateNoUnknownParams(query url.Values) error {
 	copyParams.Del(queryParam)
 	copyParams.Del(limitParam)
 	copyParams.Del(crsParam)
+	copyParams.Del(bboxParam)
+	copyParams.Del(bboxCrsParam)
 	for key := range query {
 		if deepObjectParamRegex.MatchString(key) {
 			copyParams.Del(key)

--- a/internal/search/url.go
+++ b/internal/search/url.go
@@ -9,13 +9,17 @@ import (
 	"strings"
 
 	"github.com/PDOK/gomagpie/internal/engine"
+	"github.com/PDOK/gomagpie/internal/engine/util"
 	d "github.com/PDOK/gomagpie/internal/search/domain"
+	"github.com/twpayne/go-geom"
 )
 
 const (
-	queryParam = "q"
-	limitParam = "limit"
-	crsParam   = "crs"
+	queryParam   = "q"
+	limitParam   = "limit"
+	crsParam     = "crs"
+	bboxParam    = "bbox"
+	bboxCrsParam = "bbox-crs"
 
 	limitDefault = 10
 	limitMax     = 50
@@ -25,7 +29,7 @@ var (
 	deepObjectParamRegex = regexp.MustCompile(`\w+\[\w+]`)
 )
 
-func parseQueryParams(query url.Values) (collections d.CollectionsWithParams, searchTerms string, outputSRID d.SRID, limit int, err error) {
+func parseQueryParams(query url.Values) (collections d.CollectionsWithParams, searchTerms string, outputSRID d.SRID, bbox *geom.Bounds, bboxSRID d.SRID, limit int, err error) {
 	err = validateNoUnknownParams(query)
 	if err != nil {
 		return
@@ -34,7 +38,9 @@ func parseQueryParams(query url.Values) (collections d.CollectionsWithParams, se
 	collections, collErr := parseCollections(query)
 	outputSRID, outputSRIDErr := parseCrsToPostgisSRID(query, crsParam)
 	limit, limitErr := parseLimit(query)
-	err = errors.Join(collErr, searchTermErr, limitErr, outputSRIDErr)
+	bbox, bboxSRID, bboxErr := parseBbox(query)
+
+	err = errors.Join(collErr, searchTermErr, limitErr, outputSRIDErr, bboxErr)
 	return
 }
 
@@ -143,4 +149,34 @@ func parseLimit(params url.Values) (int, error) {
 		err = errors.New("limit can't be negative")
 	}
 	return limit, err
+}
+
+func parseBbox(params url.Values) (*geom.Bounds, d.SRID, error) {
+	bboxSRID, err := parseCrsToPostgisSRID(params, bboxCrsParam)
+	if err != nil {
+		return nil, d.UndefinedSRID, err
+	}
+
+	if params.Get(bboxParam) == "" {
+		return nil, d.UndefinedSRID, nil
+	}
+	bboxValues := strings.Split(params.Get(bboxParam), ",")
+	if len(bboxValues) != 4 {
+		return nil, bboxSRID, errors.New("bbox should contain exactly 4 values " +
+			"separated by commas: minx,miny,maxx,maxy")
+	}
+
+	bboxFloats := make([]float64, len(bboxValues))
+	for i, v := range bboxValues {
+		bboxFloats[i], err = strconv.ParseFloat(v, 64)
+		if err != nil {
+			return nil, bboxSRID, fmt.Errorf("failed to parse value %s in bbox, error: %w", v, err)
+		}
+	}
+
+	bbox := geom.NewBounds(geom.XY).Set(bboxFloats...)
+	if util.SurfaceArea(bbox) <= 0 {
+		return nil, bboxSRID, errors.New("bbox has no surface area")
+	}
+	return bbox, bboxSRID, nil
 }


### PR DESCRIPTION
# Description

When searching, it is possible to pass the parameter `bbox` to limit the search to a given bounding box (which can be specified in a different CRS, in which case the `bbox-crs` parameter must also be passed).

## Type of change

- New feature
- Improvement of existing feature

# Checklist:

- [x] I've double-checked the code in this PR myself
- [x] I've left the code better than before ([boy scout rule](https://wiki.c2.com/?BoyScoutRule))
- [x] The code is readable, comments are added that explain hard or non-obvious parts.
- [x] I've expanded/improved the (unit) tests, when applicable
- [x] I've run (unit) tests that prove my solution works
- [x] There's no sensitive information like credentials in my PR