### PR TITLE
fix: store SRID of search index for bounding box transformation

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -110,6 +110,13 @@ var (
 			Required: false,
 			EnvVars:  []string{strcase.ToScreamingSnake(enableCorsFlag)},
 		},
+		sridFlag: &cli.IntFlag{
+			Name:     sridFlag,
+			EnvVars:  []string{strcase.ToScreamingSnake(sridFlag)},
+			Usage:    "SRID search-index bbox column, e.g. 28992 (RD) or 4326 (WSG84). The source geopackage its bbox should be in the same SRID.",
+			Required: false,
+			Value:    28992,
+		},
 	}
 
 	commonDBFlags = map[string]cli.Flag{
@@ -171,6 +178,7 @@ func main() {
 				serviceFlags[configFileFlag],
 				serviceFlags[enableTrailingSlashFlag],
 				serviceFlags[enableCorsFlag],
+				serviceFlags[sridFlag],
 				commonDBFlags[dbHostFlag],
 				commonDBFlags[dbPortFlag],
 				commonDBFlags[dbNameFlag],
@@ -255,6 +263,7 @@ func main() {
 					engine,
 					dbConn,
 					c.String(searchIndexFlag),
+					c.Int(sridFlag),
 					c.Path(rewritesFileFlag),
 					c.Path(synonymsFileFlag),
 					c.Int(rankNormalization),
@@ -287,13 +296,7 @@ func main() {
 					Required: false,
 					Value:    "search_index",
 				},
-				&cli.PathFlag{
-					Name:     sridFlag,
-					EnvVars:  []string{strcase.ToScreamingSnake(sridFlag)},
-					Usage:    "SRID search-index bbox column, e.g. 28992 (RD) or 4326 (WSG84). The source geopackage its bbox should be in the same SRID.",
-					Required: false,
-					Value:    "28992",
-				},
+				serviceFlags[sridFlag],
 				&cli.StringFlag{
 					Name:     languageFlag,
 					EnvVars:  []string{strcase.ToScreamingSnake(languageFlag)},

--- a/internal/search/main.go
+++ b/internal/search/main.go
@@ -26,7 +26,7 @@ type Search struct {
 	json           *jsonFeatures
 }
 
-func NewSearch(e *engine.Engine, dbConn string, searchIndex string, rewritesFile string, synonymsFile string, rankNormalization int, exactMatchMultiplier float64, primarySuggestMultiplier float64, rankThreshold int, preRankLimitMultiplier int) (*Search, error) {
+func NewSearch(e *engine.Engine, dbConn string, searchIndex string, searchIndexSrid int, rewritesFile string, synonymsFile string, rankNormalization int, exactMatchMultiplier float64, primarySuggestMultiplier float64, rankThreshold int, preRankLimitMultiplier int) (*Search, error) {
 	queryExpansion, err := NewQueryExpansion(rewritesFile, synonymsFile)
 	if err != nil {
 		return nil, err
@@ -37,6 +37,7 @@ func NewSearch(e *engine.Engine, dbConn string, searchIndex string, rewritesFile
 			e,
 			dbConn,
 			searchIndex,
+			searchIndexSrid,
 			rankNormalization,
 			exactMatchMultiplier,
 			primarySuggestMultiplier,
@@ -136,11 +137,12 @@ func (s *Search) enrichFeaturesWithHref(fc *domain.FeatureCollection, outputCRS 
 	return nil
 }
 
-func newDatasource(e *engine.Engine, dbConn string, searchIndex string, rankNormalization int, exactMatchMultiplier float64, primarySuggestMultiplier float64, rankThreshold int, preRankLimitMultiplier int) ds.Datasource {
+func newDatasource(e *engine.Engine, dbConn string, searchIndex string, searchIndexSrid int, rankNormalization int, exactMatchMultiplier float64, primarySuggestMultiplier float64, rankThreshold int, preRankLimitMultiplier int) ds.Datasource {
 	datasource, err := postgres.NewPostgres(
 		dbConn,
 		timeout,
 		searchIndex,
+		domain.SRID(searchIndexSrid),
 		rankNormalization,
 		exactMatchMultiplier,
 		primarySuggestMultiplier,

--- a/internal/search/main_test.go
+++ b/internal/search/main_test.go
@@ -62,6 +62,7 @@ func TestSearch(t *testing.T) {
 		eng,
 		dbConn,
 		testSearchIndex,
+		28992,
 		"internal/search/testdata/rewrites.csv",
 		"internal/search/testdata/synonyms.csv",
 		1,


### PR DESCRIPTION
# Description

Pass the SRID used for geometry columns in the search index (default RD/28992), and use it to transform the bounding box passed throuhg `bbox` parameter.

## Type of change

(Remove irrelevant options)

- Improvement of existing feature
- Bugfix
- Configuration change

# Checklist:

- [x] I've double-checked the code in this PR myself
- [x] I've left the code better than before ([boy scout rule](https://wiki.c2.com/?BoyScoutRule))
- [x] The code is readable, comments are added that explain hard or non-obvious parts.
- [x] I've expanded/improved the (unit) tests, when applicable
- [x] I've run (unit) tests that prove my solution works
- [x] There's no sensitive information like credentials in my PR