### PR TITLE
fix: generate `external_fid` correctly for collections with multiple feature tables

### DIFF
--- a/internal/etl/extract/geopackage.go
+++ b/internal/etl/extract/geopackage.go
@@ -99,7 +99,7 @@ func (g *GeoPackage) Extract(table config.FeatureTable, fields []string, externa
 		if len(row) != len(fields)+len(externalFidFields)+nrOfStandardFieldsInQuery {
 			return nil, fmt.Errorf("unexpected row length (%v)", len(row))
 		}
-		record, err := mapRowToRawRecord(row, fields, externalFidFields)
+		record, err := mapRowToRawRecord(row, fields, externalFidFields, table.Name)
 		if err != nil {
 			return nil, err
 		}
@@ -108,7 +108,7 @@ func (g *GeoPackage) Extract(table config.FeatureTable, fields []string, externa
 	return result, nil
 }
 
-func mapRowToRawRecord(row []any, fields []string, externalFidFields []string) (t.RawRecord, error) {
+func mapRowToRawRecord(row []any, fields []string, externalFidFields []string, tableName string) (t.RawRecord, error) {
 	bbox := row[1:5]
 
 	fid := row[0].(int64)
@@ -135,5 +135,6 @@ func mapRowToRawRecord(row []any, fields []string, externalFidFields []string) (
 		Geometry:          geometry.(*geom.Point),
 		FieldValues:       row[nrOfStandardFieldsInQuery : nrOfStandardFieldsInQuery+len(fields)],
 		ExternalFidValues: row[nrOfStandardFieldsInQuery+len(fields) : nrOfStandardFieldsInQuery+len(fields)+len(externalFidFields)],
+		ExternalFidBase:   tableName,
 	}, nil
 }

--- a/internal/etl/transform/transform.go
+++ b/internal/etl/transform/transform.go
@@ -20,6 +20,7 @@ type RawRecord struct {
 	FeatureID         int64
 	FieldValues       []any
 	ExternalFidValues []any
+	ExternalFidBase   string
 	Bbox              *geom.Bounds
 	GeometryType      string
 	Geometry          *geom.Point
@@ -71,7 +72,7 @@ func (t Transformer) Transform(records []RawRecord, collection config.GeoSpatial
 
 		geometry := r.Geometry
 
-		externalFid, err := generateExternalFid(collection.ID, collection.Search.ETL.ExternalFid, r.ExternalFidValues)
+		externalFid, err := generateExternalFid(r.ExternalFidBase, collection.Search.ETL.ExternalFid, r.ExternalFidValues)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/search/testdata/expected-search-den-building-collection-wgs84.json
+++ b/internal/search/testdata/expected-search-den-building-collection-wgs84.json
@@ -18,7 +18,7 @@
         "collectionVersion": "1",
         "displayName": "Abbewaal - Den Burg 1",
         "highlight": "Abbewaal <b>Den</b> Burg",
-        "href": "https://example.com/ogc/v1/collections/buildings/items/d731442a-4505-52c2-b6c6-2a06dc8c92ef?f=json",
+        "href": "https://example.com/ogc/v1/collections/buildings/items/edeb9d6b-e2c1-567e-a381-9df2a276490d?f=json",
         "score": 0.14426951110363007
       },
       "geometry": {
@@ -29,13 +29,13 @@
         ]
       },
       "bbox": null,
-      "id": "d731442a-4505-52c2-b6c6-2a06dc8c92ef",
+      "id": "edeb9d6b-e2c1-567e-a381-9df2a276490d",
       "links": [
         {
           "rel": "canonical",
           "title": "The actual feature in the corresponding OGC API",
           "type": "application/geo+json",
-          "href": "https://example.com/ogc/v1/collections/buildings/items/d731442a-4505-52c2-b6c6-2a06dc8c92ef?f=json"
+          "href": "https://example.com/ogc/v1/collections/buildings/items/edeb9d6b-e2c1-567e-a381-9df2a276490d?f=json"
         }
       ]
     },
@@ -47,7 +47,7 @@
         "collectionVersion": "1",
         "displayName": "Abbewaal - Den Burg 1",
         "highlight": "Abbewaal <b>Den</b> Burg",
-        "href": "https://example.com/ogc/v1/collections/buildings/items/67f0c3f1-f2cd-5002-90b4-9a344c66dbf0?f=json",
+        "href": "https://example.com/ogc/v1/collections/buildings/items/2d254321-120d-550a-9b7b-3bc7e7c9dfd1?f=json",
         "score": 0.14426951110363007
       },
       "geometry": {
@@ -58,13 +58,13 @@
         ]
       },
       "bbox": null,
-      "id": "67f0c3f1-f2cd-5002-90b4-9a344c66dbf0",
+      "id": "2d254321-120d-550a-9b7b-3bc7e7c9dfd1",
       "links": [
         {
           "rel": "canonical",
           "title": "The actual feature in the corresponding OGC API",
           "type": "application/geo+json",
-          "href": "https://example.com/ogc/v1/collections/buildings/items/67f0c3f1-f2cd-5002-90b4-9a344c66dbf0?f=json"
+          "href": "https://example.com/ogc/v1/collections/buildings/items/2d254321-120d-550a-9b7b-3bc7e7c9dfd1?f=json"
         }
       ]
     },
@@ -76,7 +76,7 @@
         "collectionVersion": "1",
         "displayName": "Abbewaal - Den Burg 2",
         "highlight": "Abbewaal <b>Den</b> Burg",
-        "href": "https://example.com/ogc/v1/collections/buildings/items/9f4bbf2b-79dc-57c2-b96a-34b5c6ef09ea?f=json",
+        "href": "https://example.com/ogc/v1/collections/buildings/items/96e99bb3-95cc-573b-a16d-3b7d930443cc?f=json",
         "score": 0.14426951110363007
       },
       "geometry": {
@@ -87,13 +87,13 @@
         ]
       },
       "bbox": null,
-      "id": "9f4bbf2b-79dc-57c2-b96a-34b5c6ef09ea",
+      "id": "96e99bb3-95cc-573b-a16d-3b7d930443cc",
       "links": [
         {
           "rel": "canonical",
           "title": "The actual feature in the corresponding OGC API",
           "type": "application/geo+json",
-          "href": "https://example.com/ogc/v1/collections/buildings/items/9f4bbf2b-79dc-57c2-b96a-34b5c6ef09ea?f=json"
+          "href": "https://example.com/ogc/v1/collections/buildings/items/96e99bb3-95cc-573b-a16d-3b7d930443cc?f=json"
         }
       ]
     },
@@ -105,7 +105,7 @@
         "collectionVersion": "1",
         "displayName": "Abbewaal - Den Burg 2",
         "highlight": "Abbewaal <b>Den</b> Burg",
-        "href": "https://example.com/ogc/v1/collections/buildings/items/410a6a8e-045c-5bdc-8ae9-49e323c9a117?f=json",
+        "href": "https://example.com/ogc/v1/collections/buildings/items/e2090965-5a66-57b4-ade8-ca94a5f6deac?f=json",
         "score": 0.14426951110363007
       },
       "geometry": {
@@ -116,13 +116,13 @@
         ]
       },
       "bbox": null,
-      "id": "410a6a8e-045c-5bdc-8ae9-49e323c9a117",
+      "id": "e2090965-5a66-57b4-ade8-ca94a5f6deac",
       "links": [
         {
           "rel": "canonical",
           "title": "The actual feature in the corresponding OGC API",
           "type": "application/geo+json",
-          "href": "https://example.com/ogc/v1/collections/buildings/items/410a6a8e-045c-5bdc-8ae9-49e323c9a117?f=json"
+          "href": "https://example.com/ogc/v1/collections/buildings/items/e2090965-5a66-57b4-ade8-ca94a5f6deac?f=json"
         }
       ]
     },
@@ -134,7 +134,7 @@
         "collectionVersion": "1",
         "displayName": "Abbewaal - Den Burg 3",
         "highlight": "Abbewaal <b>Den</b> Burg",
-        "href": "https://example.com/ogc/v1/collections/buildings/items/0bc2b40f-2da3-52d0-93c4-877d4cfbf289?f=json",
+        "href": "https://example.com/ogc/v1/collections/buildings/items/9058626b-3217-549b-9732-4e58e9303d95?f=json",
         "score": 0.14426951110363007
       },
       "geometry": {
@@ -145,13 +145,13 @@
         ]
       },
       "bbox": null,
-      "id": "0bc2b40f-2da3-52d0-93c4-877d4cfbf289",
+      "id": "9058626b-3217-549b-9732-4e58e9303d95",
       "links": [
         {
           "rel": "canonical",
           "title": "The actual feature in the corresponding OGC API",
           "type": "application/geo+json",
-          "href": "https://example.com/ogc/v1/collections/buildings/items/0bc2b40f-2da3-52d0-93c4-877d4cfbf289?f=json"
+          "href": "https://example.com/ogc/v1/collections/buildings/items/9058626b-3217-549b-9732-4e58e9303d95?f=json"
         }
       ]
     },
@@ -163,7 +163,7 @@
         "collectionVersion": "1",
         "displayName": "Abbewaal - Den Burg 3",
         "highlight": "Abbewaal <b>Den</b> Burg",
-        "href": "https://example.com/ogc/v1/collections/buildings/items/fdb22c13-bcd0-5409-b9f8-a11cddee9d68?f=json",
+        "href": "https://example.com/ogc/v1/collections/buildings/items/cc085f6e-16bd-56df-b69f-cbc181098359?f=json",
         "score": 0.14426951110363007
       },
       "geometry": {
@@ -174,13 +174,13 @@
         ]
       },
       "bbox": null,
-      "id": "fdb22c13-bcd0-5409-b9f8-a11cddee9d68",
+      "id": "cc085f6e-16bd-56df-b69f-cbc181098359",
       "links": [
         {
           "rel": "canonical",
           "title": "The actual feature in the corresponding OGC API",
           "type": "application/geo+json",
-          "href": "https://example.com/ogc/v1/collections/buildings/items/fdb22c13-bcd0-5409-b9f8-a11cddee9d68?f=json"
+          "href": "https://example.com/ogc/v1/collections/buildings/items/cc085f6e-16bd-56df-b69f-cbc181098359?f=json"
         }
       ]
     },
@@ -192,7 +192,7 @@
         "collectionVersion": "1",
         "displayName": "Abbewaal - Den Burg 4",
         "highlight": "Abbewaal <b>Den</b> Burg",
-        "href": "https://example.com/ogc/v1/collections/buildings/items/098f570f-790d-5b6f-b4c7-1abcb3dd6f70?f=json",
+        "href": "https://example.com/ogc/v1/collections/buildings/items/7f514f2b-7d82-5874-bebb-0e423f08c901?f=json",
         "score": 0.14426951110363007
       },
       "geometry": {
@@ -203,13 +203,13 @@
         ]
       },
       "bbox": null,
-      "id": "098f570f-790d-5b6f-b4c7-1abcb3dd6f70",
+      "id": "7f514f2b-7d82-5874-bebb-0e423f08c901",
       "links": [
         {
           "rel": "canonical",
           "title": "The actual feature in the corresponding OGC API",
           "type": "application/geo+json",
-          "href": "https://example.com/ogc/v1/collections/buildings/items/098f570f-790d-5b6f-b4c7-1abcb3dd6f70?f=json"
+          "href": "https://example.com/ogc/v1/collections/buildings/items/7f514f2b-7d82-5874-bebb-0e423f08c901?f=json"
         }
       ]
     },
@@ -221,7 +221,7 @@
         "collectionVersion": "1",
         "displayName": "Abbewaal - Den Burg 4 A",
         "highlight": "Abbewaal <b>Den</b> Burg",
-        "href": "https://example.com/ogc/v1/collections/buildings/items/0f1fa0ef-dfe0-5edd-aa5a-f861e6139e31?f=json",
+        "href": "https://example.com/ogc/v1/collections/buildings/items/63b9fa8f-7693-510c-be11-2f8ffec21fe0?f=json",
         "score": 0.14426951110363007
       },
       "geometry": {
@@ -232,13 +232,13 @@
         ]
       },
       "bbox": null,
-      "id": "0f1fa0ef-dfe0-5edd-aa5a-f861e6139e31",
+      "id": "63b9fa8f-7693-510c-be11-2f8ffec21fe0",
       "links": [
         {
           "rel": "canonical",
           "title": "The actual feature in the corresponding OGC API",
           "type": "application/geo+json",
-          "href": "https://example.com/ogc/v1/collections/buildings/items/0f1fa0ef-dfe0-5edd-aa5a-f861e6139e31?f=json"
+          "href": "https://example.com/ogc/v1/collections/buildings/items/63b9fa8f-7693-510c-be11-2f8ffec21fe0?f=json"
         }
       ]
     },
@@ -250,7 +250,7 @@
         "collectionVersion": "1",
         "displayName": "Abbewaal - Den Burg 4 A",
         "highlight": "Abbewaal <b>Den</b> Burg",
-        "href": "https://example.com/ogc/v1/collections/buildings/items/1c46c774-2088-50d6-8af9-b6bc9802da2e?f=json",
+        "href": "https://example.com/ogc/v1/collections/buildings/items/7eac3ad0-e13c-54a9-9a27-558bdba2a1f5?f=json",
         "score": 0.14426951110363007
       },
       "geometry": {
@@ -261,13 +261,13 @@
         ]
       },
       "bbox": null,
-      "id": "1c46c774-2088-50d6-8af9-b6bc9802da2e",
+      "id": "7eac3ad0-e13c-54a9-9a27-558bdba2a1f5",
       "links": [
         {
           "rel": "canonical",
           "title": "The actual feature in the corresponding OGC API",
           "type": "application/geo+json",
-          "href": "https://example.com/ogc/v1/collections/buildings/items/1c46c774-2088-50d6-8af9-b6bc9802da2e?f=json"
+          "href": "https://example.com/ogc/v1/collections/buildings/items/7eac3ad0-e13c-54a9-9a27-558bdba2a1f5?f=json"
         }
       ]
     },
@@ -279,7 +279,7 @@
         "collectionVersion": "1",
         "displayName": "Abbewaal - Den Burg 4 A",
         "highlight": "Abbewaal <b>Den</b> Burg",
-        "href": "https://example.com/ogc/v1/collections/buildings/items/1a37ee51-d22b-568d-bc58-e705bc959e57?f=json",
+        "href": "https://example.com/ogc/v1/collections/buildings/items/1bccc02c-4be3-523b-a4d1-21edae710d3d?f=json",
         "score": 0.14426951110363007
       },
       "geometry": {
@@ -290,13 +290,13 @@
         ]
       },
       "bbox": null,
-      "id": "1a37ee51-d22b-568d-bc58-e705bc959e57",
+      "id": "1bccc02c-4be3-523b-a4d1-21edae710d3d",
       "links": [
         {
           "rel": "canonical",
           "title": "The actual feature in the corresponding OGC API",
           "type": "application/geo+json",
-          "href": "https://example.com/ogc/v1/collections/buildings/items/1a37ee51-d22b-568d-bc58-e705bc959e57?f=json"
+          "href": "https://example.com/ogc/v1/collections/buildings/items/1bccc02c-4be3-523b-a4d1-21edae710d3d?f=json"
         }
       ]
     }

--- a/internal/search/testdata/expected-search-den-multiple-collection-single-output-wgs84.json
+++ b/internal/search/testdata/expected-search-den-multiple-collection-single-output-wgs84.json
@@ -18,7 +18,7 @@
         "collectionVersion": "1",
         "displayName": "Abbewaal - Den Burg 1",
         "highlight": "Abbewaal <b>Den</b> Burg",
-        "href": "https://example.com/ogc/v1/collections/buildings/items/67f0c3f1-f2cd-5002-90b4-9a344c66dbf0?f=json",
+        "href": "https://example.com/ogc/v1/collections/buildings/items/2d254321-120d-550a-9b7b-3bc7e7c9dfd1?f=json",
         "score": 0.14426951110363007
       },
       "geometry": {
@@ -29,13 +29,13 @@
         ]
       },
       "bbox": null,
-      "id": "67f0c3f1-f2cd-5002-90b4-9a344c66dbf0",
+      "id": "2d254321-120d-550a-9b7b-3bc7e7c9dfd1",
       "links": [
         {
           "rel": "canonical",
           "title": "The actual feature in the corresponding OGC API",
           "type": "application/geo+json",
-          "href": "https://example.com/ogc/v1/collections/buildings/items/67f0c3f1-f2cd-5002-90b4-9a344c66dbf0?f=json"
+          "href": "https://example.com/ogc/v1/collections/buildings/items/2d254321-120d-550a-9b7b-3bc7e7c9dfd1?f=json"
         }
       ]
     },
@@ -47,7 +47,7 @@
         "collectionVersion": "1",
         "displayName": "Abbewaal - Den Burg 1",
         "highlight": "Abbewaal <b>Den</b> Burg",
-        "href": "https://example.com/ogc/v1/collections/buildings/items/d731442a-4505-52c2-b6c6-2a06dc8c92ef?f=json",
+        "href": "https://example.com/ogc/v1/collections/buildings/items/edeb9d6b-e2c1-567e-a381-9df2a276490d?f=json",
         "score": 0.14426951110363007
       },
       "geometry": {
@@ -58,13 +58,13 @@
         ]
       },
       "bbox": null,
-      "id": "d731442a-4505-52c2-b6c6-2a06dc8c92ef",
+      "id": "edeb9d6b-e2c1-567e-a381-9df2a276490d",
       "links": [
         {
           "rel": "canonical",
           "title": "The actual feature in the corresponding OGC API",
           "type": "application/geo+json",
-          "href": "https://example.com/ogc/v1/collections/buildings/items/d731442a-4505-52c2-b6c6-2a06dc8c92ef?f=json"
+          "href": "https://example.com/ogc/v1/collections/buildings/items/edeb9d6b-e2c1-567e-a381-9df2a276490d?f=json"
         }
       ]
     },
@@ -76,7 +76,7 @@
         "collectionVersion": "1",
         "displayName": "Abbewaal - Den Burg 2",
         "highlight": "Abbewaal <b>Den</b> Burg",
-        "href": "https://example.com/ogc/v1/collections/buildings/items/410a6a8e-045c-5bdc-8ae9-49e323c9a117?f=json",
+        "href": "https://example.com/ogc/v1/collections/buildings/items/e2090965-5a66-57b4-ade8-ca94a5f6deac?f=json",
         "score": 0.14426951110363007
       },
       "geometry": {
@@ -87,13 +87,13 @@
         ]
       },
       "bbox": null,
-      "id": "410a6a8e-045c-5bdc-8ae9-49e323c9a117",
+      "id": "e2090965-5a66-57b4-ade8-ca94a5f6deac",
       "links": [
         {
           "rel": "canonical",
           "title": "The actual feature in the corresponding OGC API",
           "type": "application/geo+json",
-          "href": "https://example.com/ogc/v1/collections/buildings/items/410a6a8e-045c-5bdc-8ae9-49e323c9a117?f=json"
+          "href": "https://example.com/ogc/v1/collections/buildings/items/e2090965-5a66-57b4-ade8-ca94a5f6deac?f=json"
         }
       ]
     },
@@ -105,7 +105,7 @@
         "collectionVersion": "1",
         "displayName": "Abbewaal - Den Burg 2",
         "highlight": "Abbewaal <b>Den</b> Burg",
-        "href": "https://example.com/ogc/v1/collections/buildings/items/9f4bbf2b-79dc-57c2-b96a-34b5c6ef09ea?f=json",
+        "href": "https://example.com/ogc/v1/collections/buildings/items/96e99bb3-95cc-573b-a16d-3b7d930443cc?f=json",
         "score": 0.14426951110363007
       },
       "geometry": {
@@ -116,13 +116,13 @@
         ]
       },
       "bbox": null,
-      "id": "9f4bbf2b-79dc-57c2-b96a-34b5c6ef09ea",
+      "id": "96e99bb3-95cc-573b-a16d-3b7d930443cc",
       "links": [
         {
           "rel": "canonical",
           "title": "The actual feature in the corresponding OGC API",
           "type": "application/geo+json",
-          "href": "https://example.com/ogc/v1/collections/buildings/items/9f4bbf2b-79dc-57c2-b96a-34b5c6ef09ea?f=json"
+          "href": "https://example.com/ogc/v1/collections/buildings/items/96e99bb3-95cc-573b-a16d-3b7d930443cc?f=json"
         }
       ]
     },
@@ -134,7 +134,7 @@
         "collectionVersion": "1",
         "displayName": "Abbewaal - Den Burg 3",
         "highlight": "Abbewaal <b>Den</b> Burg",
-        "href": "https://example.com/ogc/v1/collections/buildings/items/fdb22c13-bcd0-5409-b9f8-a11cddee9d68?f=json",
+        "href": "https://example.com/ogc/v1/collections/buildings/items/cc085f6e-16bd-56df-b69f-cbc181098359?f=json",
         "score": 0.14426951110363007
       },
       "geometry": {
@@ -145,13 +145,13 @@
         ]
       },
       "bbox": null,
-      "id": "fdb22c13-bcd0-5409-b9f8-a11cddee9d68",
+      "id": "cc085f6e-16bd-56df-b69f-cbc181098359",
       "links": [
         {
           "rel": "canonical",
           "title": "The actual feature in the corresponding OGC API",
           "type": "application/geo+json",
-          "href": "https://example.com/ogc/v1/collections/buildings/items/fdb22c13-bcd0-5409-b9f8-a11cddee9d68?f=json"
+          "href": "https://example.com/ogc/v1/collections/buildings/items/cc085f6e-16bd-56df-b69f-cbc181098359?f=json"
         }
       ]
     },
@@ -163,7 +163,7 @@
         "collectionVersion": "1",
         "displayName": "Abbewaal - Den Burg 3",
         "highlight": "Abbewaal <b>Den</b> Burg",
-        "href": "https://example.com/ogc/v1/collections/buildings/items/0bc2b40f-2da3-52d0-93c4-877d4cfbf289?f=json",
+        "href": "https://example.com/ogc/v1/collections/buildings/items/9058626b-3217-549b-9732-4e58e9303d95?f=json",
         "score": 0.14426951110363007
       },
       "geometry": {
@@ -174,13 +174,13 @@
         ]
       },
       "bbox": null,
-      "id": "0bc2b40f-2da3-52d0-93c4-877d4cfbf289",
+      "id": "9058626b-3217-549b-9732-4e58e9303d95",
       "links": [
         {
           "rel": "canonical",
           "title": "The actual feature in the corresponding OGC API",
           "type": "application/geo+json",
-          "href": "https://example.com/ogc/v1/collections/buildings/items/0bc2b40f-2da3-52d0-93c4-877d4cfbf289?f=json"
+          "href": "https://example.com/ogc/v1/collections/buildings/items/9058626b-3217-549b-9732-4e58e9303d95?f=json"
         }
       ]
     },
@@ -192,7 +192,7 @@
         "collectionVersion": "1",
         "displayName": "Abbewaal - Den Burg 4",
         "highlight": "Abbewaal <b>Den</b> Burg",
-        "href": "https://example.com/ogc/v1/collections/buildings/items/098f570f-790d-5b6f-b4c7-1abcb3dd6f70?f=json",
+        "href": "https://example.com/ogc/v1/collections/buildings/items/7f514f2b-7d82-5874-bebb-0e423f08c901?f=json",
         "score": 0.14426951110363007
       },
       "geometry": {
@@ -203,13 +203,13 @@
         ]
       },
       "bbox": null,
-      "id": "098f570f-790d-5b6f-b4c7-1abcb3dd6f70",
+      "id": "7f514f2b-7d82-5874-bebb-0e423f08c901",
       "links": [
         {
           "rel": "canonical",
           "title": "The actual feature in the corresponding OGC API",
           "type": "application/geo+json",
-          "href": "https://example.com/ogc/v1/collections/buildings/items/098f570f-790d-5b6f-b4c7-1abcb3dd6f70?f=json"
+          "href": "https://example.com/ogc/v1/collections/buildings/items/7f514f2b-7d82-5874-bebb-0e423f08c901?f=json"
         }
       ]
     },
@@ -221,7 +221,7 @@
         "collectionVersion": "1",
         "displayName": "Abbewaal - Den Burg 4 A",
         "highlight": "Abbewaal <b>Den</b> Burg",
-        "href": "https://example.com/ogc/v1/collections/buildings/items/1c46c774-2088-50d6-8af9-b6bc9802da2e?f=json",
+        "href": "https://example.com/ogc/v1/collections/buildings/items/7eac3ad0-e13c-54a9-9a27-558bdba2a1f5?f=json",
         "score": 0.14426951110363007
       },
       "geometry": {
@@ -232,13 +232,13 @@
         ]
       },
       "bbox": null,
-      "id": "1c46c774-2088-50d6-8af9-b6bc9802da2e",
+      "id": "7eac3ad0-e13c-54a9-9a27-558bdba2a1f5",
       "links": [
         {
           "rel": "canonical",
           "title": "The actual feature in the corresponding OGC API",
           "type": "application/geo+json",
-          "href": "https://example.com/ogc/v1/collections/buildings/items/1c46c774-2088-50d6-8af9-b6bc9802da2e?f=json"
+          "href": "https://example.com/ogc/v1/collections/buildings/items/7eac3ad0-e13c-54a9-9a27-558bdba2a1f5?f=json"
         }
       ]
     },
@@ -250,7 +250,7 @@
         "collectionVersion": "1",
         "displayName": "Abbewaal - Den Burg 4 A",
         "highlight": "Abbewaal <b>Den</b> Burg",
-        "href": "https://example.com/ogc/v1/collections/buildings/items/1a37ee51-d22b-568d-bc58-e705bc959e57?f=json",
+        "href": "https://example.com/ogc/v1/collections/buildings/items/1bccc02c-4be3-523b-a4d1-21edae710d3d?f=json",
         "score": 0.14426951110363007
       },
       "geometry": {
@@ -261,13 +261,13 @@
         ]
       },
       "bbox": null,
-      "id": "1a37ee51-d22b-568d-bc58-e705bc959e57",
+      "id": "1bccc02c-4be3-523b-a4d1-21edae710d3d",
       "links": [
         {
           "rel": "canonical",
           "title": "The actual feature in the corresponding OGC API",
           "type": "application/geo+json",
-          "href": "https://example.com/ogc/v1/collections/buildings/items/1a37ee51-d22b-568d-bc58-e705bc959e57?f=json"
+          "href": "https://example.com/ogc/v1/collections/buildings/items/1bccc02c-4be3-523b-a4d1-21edae710d3d?f=json"
         }
       ]
     },
@@ -279,7 +279,7 @@
         "collectionVersion": "1",
         "displayName": "Abbewaal - Den Burg 4 A",
         "highlight": "Abbewaal <b>Den</b> Burg",
-        "href": "https://example.com/ogc/v1/collections/buildings/items/0f1fa0ef-dfe0-5edd-aa5a-f861e6139e31?f=json",
+        "href": "https://example.com/ogc/v1/collections/buildings/items/63b9fa8f-7693-510c-be11-2f8ffec21fe0?f=json",
         "score": 0.14426951110363007
       },
       "geometry": {
@@ -290,13 +290,13 @@
         ]
       },
       "bbox": null,
-      "id": "0f1fa0ef-dfe0-5edd-aa5a-f861e6139e31",
+      "id": "63b9fa8f-7693-510c-be11-2f8ffec21fe0",
       "links": [
         {
           "rel": "canonical",
           "title": "The actual feature in the corresponding OGC API",
           "type": "application/geo+json",
-          "href": "https://example.com/ogc/v1/collections/buildings/items/0f1fa0ef-dfe0-5edd-aa5a-f861e6139e31?f=json"
+          "href": "https://example.com/ogc/v1/collections/buildings/items/63b9fa8f-7693-510c-be11-2f8ffec21fe0?f=json"
         }
       ]
     },
@@ -308,7 +308,7 @@
         "collectionVersion": "1",
         "displayName": "Abbewaal - Den Burg 4 B",
         "highlight": "Abbewaal <b>Den</b> Burg",
-        "href": "https://example.com/ogc/v1/collections/buildings/items/3703fecd-f7b2-5ff7-a961-0ab6d62a454a?f=json",
+        "href": "https://example.com/ogc/v1/collections/buildings/items/58ca630f-ce44-57c8-abcc-5bd41f2d6980?f=json",
         "score": 0.14426951110363007
       },
       "geometry": {
@@ -319,13 +319,13 @@
         ]
       },
       "bbox": null,
-      "id": "3703fecd-f7b2-5ff7-a961-0ab6d62a454a",
+      "id": "58ca630f-ce44-57c8-abcc-5bd41f2d6980",
       "links": [
         {
           "rel": "canonical",
           "title": "The actual feature in the corresponding OGC API",
           "type": "application/geo+json",
-          "href": "https://example.com/ogc/v1/collections/buildings/items/3703fecd-f7b2-5ff7-a961-0ab6d62a454a?f=json"
+          "href": "https://example.com/ogc/v1/collections/buildings/items/58ca630f-ce44-57c8-abcc-5bd41f2d6980?f=json"
         }
       ]
     },
@@ -337,7 +337,7 @@
         "collectionVersion": "1",
         "displayName": "Abbewaal - Den Burg 5",
         "highlight": "Abbewaal <b>Den</b> Burg",
-        "href": "https://example.com/ogc/v1/collections/buildings/items/28c3612d-df78-50b9-b2cf-5ac512ce2ae2?f=json",
+        "href": "https://example.com/ogc/v1/collections/buildings/items/0fc2546e-e729-5a03-ad34-588ca3256a78?f=json",
         "score": 0.14426951110363007
       },
       "geometry": {
@@ -348,13 +348,13 @@
         ]
       },
       "bbox": null,
-      "id": "28c3612d-df78-50b9-b2cf-5ac512ce2ae2",
+      "id": "0fc2546e-e729-5a03-ad34-588ca3256a78",
       "links": [
         {
           "rel": "canonical",
           "title": "The actual feature in the corresponding OGC API",
           "type": "application/geo+json",
-          "href": "https://example.com/ogc/v1/collections/buildings/items/28c3612d-df78-50b9-b2cf-5ac512ce2ae2?f=json"
+          "href": "https://example.com/ogc/v1/collections/buildings/items/0fc2546e-e729-5a03-ad34-588ca3256a78?f=json"
         }
       ]
     },
@@ -366,7 +366,7 @@
         "collectionVersion": "1",
         "displayName": "Abbewaal - Den Burg 5",
         "highlight": "Abbewaal <b>Den</b> Burg",
-        "href": "https://example.com/ogc/v1/collections/buildings/items/68b11e8b-d2df-5514-9dae-3f64fb3f5275?f=json",
+        "href": "https://example.com/ogc/v1/collections/buildings/items/6a4cad7b-6048-5517-be31-d8c5dd2be432?f=json",
         "score": 0.14426951110363007
       },
       "geometry": {
@@ -377,13 +377,13 @@
         ]
       },
       "bbox": null,
-      "id": "68b11e8b-d2df-5514-9dae-3f64fb3f5275",
+      "id": "6a4cad7b-6048-5517-be31-d8c5dd2be432",
       "links": [
         {
           "rel": "canonical",
           "title": "The actual feature in the corresponding OGC API",
           "type": "application/geo+json",
-          "href": "https://example.com/ogc/v1/collections/buildings/items/68b11e8b-d2df-5514-9dae-3f64fb3f5275?f=json"
+          "href": "https://example.com/ogc/v1/collections/buildings/items/6a4cad7b-6048-5517-be31-d8c5dd2be432?f=json"
         }
       ]
     },
@@ -395,7 +395,7 @@
         "collectionVersion": "1",
         "displayName": "Abbewaal - Den Burg 5",
         "highlight": "Abbewaal <b>Den</b> Burg",
-        "href": "https://example.com/ogc/v1/collections/buildings/items/162b4198-774b-5b82-a8fc-446bcc3cc0b1?f=json",
+        "href": "https://example.com/ogc/v1/collections/buildings/items/7275f5a7-90b1-5558-bf17-c2dec34796b2?f=json",
         "score": 0.14426951110363007
       },
       "geometry": {
@@ -406,13 +406,13 @@
         ]
       },
       "bbox": null,
-      "id": "162b4198-774b-5b82-a8fc-446bcc3cc0b1",
+      "id": "7275f5a7-90b1-5558-bf17-c2dec34796b2",
       "links": [
         {
           "rel": "canonical",
           "title": "The actual feature in the corresponding OGC API",
           "type": "application/geo+json",
-          "href": "https://example.com/ogc/v1/collections/buildings/items/162b4198-774b-5b82-a8fc-446bcc3cc0b1?f=json"
+          "href": "https://example.com/ogc/v1/collections/buildings/items/7275f5a7-90b1-5558-bf17-c2dec34796b2?f=json"
         }
       ]
     },
@@ -424,7 +424,7 @@
         "collectionVersion": "1",
         "displayName": "Abbewaal - Den Burg 5",
         "highlight": "Abbewaal <b>Den</b> Burg",
-        "href": "https://example.com/ogc/v1/collections/buildings/items/7261db92-d02f-5591-99ac-ca1cc8da0a22?f=json",
+        "href": "https://example.com/ogc/v1/collections/buildings/items/69301861-c4a6-509e-a173-b3c08d408add?f=json",
         "score": 0.14426951110363007
       },
       "geometry": {
@@ -435,13 +435,13 @@
         ]
       },
       "bbox": null,
-      "id": "7261db92-d02f-5591-99ac-ca1cc8da0a22",
+      "id": "69301861-c4a6-509e-a173-b3c08d408add",
       "links": [
         {
           "rel": "canonical",
           "title": "The actual feature in the corresponding OGC API",
           "type": "application/geo+json",
-          "href": "https://example.com/ogc/v1/collections/buildings/items/7261db92-d02f-5591-99ac-ca1cc8da0a22?f=json"
+          "href": "https://example.com/ogc/v1/collections/buildings/items/69301861-c4a6-509e-a173-b3c08d408add?f=json"
         }
       ]
     },
@@ -453,7 +453,7 @@
         "collectionVersion": "1",
         "displayName": "Abbewaal - Den Burg 5",
         "highlight": "Abbewaal <b>Den</b> Burg",
-        "href": "https://example.com/ogc/v1/collections/buildings/items/64b825c5-103e-5d89-a065-1dd019f4d6b5?f=json",
+        "href": "https://example.com/ogc/v1/collections/buildings/items/ff29fd39-e6f0-5b0a-b34a-ba07fb955e16?f=json",
         "score": 0.14426951110363007
       },
       "geometry": {
@@ -464,13 +464,13 @@
         ]
       },
       "bbox": null,
-      "id": "64b825c5-103e-5d89-a065-1dd019f4d6b5",
+      "id": "ff29fd39-e6f0-5b0a-b34a-ba07fb955e16",
       "links": [
         {
           "rel": "canonical",
           "title": "The actual feature in the corresponding OGC API",
           "type": "application/geo+json",
-          "href": "https://example.com/ogc/v1/collections/buildings/items/64b825c5-103e-5d89-a065-1dd019f4d6b5?f=json"
+          "href": "https://example.com/ogc/v1/collections/buildings/items/ff29fd39-e6f0-5b0a-b34a-ba07fb955e16?f=json"
         }
       ]
     },
@@ -482,7 +482,7 @@
         "collectionVersion": "1",
         "displayName": "Abbewaal - Den Burg 5 A",
         "highlight": "Abbewaal <b>Den</b> Burg",
-        "href": "https://example.com/ogc/v1/collections/buildings/items/f9d9d702-a77d-51f5-a586-709e9bd2e507?f=json",
+        "href": "https://example.com/ogc/v1/collections/buildings/items/abd11868-2c16-5bac-9e24-997db4365f4d?f=json",
         "score": 0.14426951110363007
       },
       "geometry": {
@@ -493,13 +493,13 @@
         ]
       },
       "bbox": null,
-      "id": "f9d9d702-a77d-51f5-a586-709e9bd2e507",
+      "id": "abd11868-2c16-5bac-9e24-997db4365f4d",
       "links": [
         {
           "rel": "canonical",
           "title": "The actual feature in the corresponding OGC API",
           "type": "application/geo+json",
-          "href": "https://example.com/ogc/v1/collections/buildings/items/f9d9d702-a77d-51f5-a586-709e9bd2e507?f=json"
+          "href": "https://example.com/ogc/v1/collections/buildings/items/abd11868-2c16-5bac-9e24-997db4365f4d?f=json"
         }
       ]
     },
@@ -511,7 +511,7 @@
         "collectionVersion": "1",
         "displayName": "Abbewaal - Den Burg 5 A",
         "highlight": "Abbewaal <b>Den</b> Burg",
-        "href": "https://example.com/ogc/v1/collections/buildings/items/47fd2cb7-35ec-5e39-82f8-bf2c30e905b8?f=json",
+        "href": "https://example.com/ogc/v1/collections/buildings/items/60182459-1ef9-5953-b9e1-95f416b9fbf9?f=json",
         "score": 0.14426951110363007
       },
       "geometry": {
@@ -522,13 +522,13 @@
         ]
       },
       "bbox": null,
-      "id": "47fd2cb7-35ec-5e39-82f8-bf2c30e905b8",
+      "id": "60182459-1ef9-5953-b9e1-95f416b9fbf9",
       "links": [
         {
           "rel": "canonical",
           "title": "The actual feature in the corresponding OGC API",
           "type": "application/geo+json",
-          "href": "https://example.com/ogc/v1/collections/buildings/items/47fd2cb7-35ec-5e39-82f8-bf2c30e905b8?f=json"
+          "href": "https://example.com/ogc/v1/collections/buildings/items/60182459-1ef9-5953-b9e1-95f416b9fbf9?f=json"
         }
       ]
     },
@@ -540,7 +540,7 @@
         "collectionVersion": "1",
         "displayName": "Abbewaal - Den Burg 5 A",
         "highlight": "Abbewaal <b>Den</b> Burg",
-        "href": "https://example.com/ogc/v1/collections/buildings/items/a3530f3f-fec3-559e-b8c5-7b5915a4093b?f=json",
+        "href": "https://example.com/ogc/v1/collections/buildings/items/c8dff799-18f6-5c09-8d70-027d3ef91222?f=json",
         "score": 0.14426951110363007
       },
       "geometry": {
@@ -551,13 +551,13 @@
         ]
       },
       "bbox": null,
-      "id": "a3530f3f-fec3-559e-b8c5-7b5915a4093b",
+      "id": "c8dff799-18f6-5c09-8d70-027d3ef91222",
       "links": [
         {
           "rel": "canonical",
           "title": "The actual feature in the corresponding OGC API",
           "type": "application/geo+json",
-          "href": "https://example.com/ogc/v1/collections/buildings/items/a3530f3f-fec3-559e-b8c5-7b5915a4093b?f=json"
+          "href": "https://example.com/ogc/v1/collections/buildings/items/c8dff799-18f6-5c09-8d70-027d3ef91222?f=json"
         }
       ]
     },
@@ -569,7 +569,7 @@
         "collectionVersion": "1",
         "displayName": "Abbewaal - Den Burg 5 B",
         "highlight": "Abbewaal <b>Den</b> Burg",
-        "href": "https://example.com/ogc/v1/collections/buildings/items/49627866-bc7d-5fbd-914d-d9120371644a?f=json",
+        "href": "https://example.com/ogc/v1/collections/buildings/items/56a08a19-5ca5-5764-ae7f-0c0fc6c8819c?f=json",
         "score": 0.14426951110363007
       },
       "geometry": {
@@ -580,13 +580,13 @@
         ]
       },
       "bbox": null,
-      "id": "49627866-bc7d-5fbd-914d-d9120371644a",
+      "id": "56a08a19-5ca5-5764-ae7f-0c0fc6c8819c",
       "links": [
         {
           "rel": "canonical",
           "title": "The actual feature in the corresponding OGC API",
           "type": "application/geo+json",
-          "href": "https://example.com/ogc/v1/collections/buildings/items/49627866-bc7d-5fbd-914d-d9120371644a?f=json"
+          "href": "https://example.com/ogc/v1/collections/buildings/items/56a08a19-5ca5-5764-ae7f-0c0fc6c8819c?f=json"
         }
       ]
     }


### PR DESCRIPTION
# Description

A search collection can include multiple feature tables (i.e., OGC API Features collections). When generating values for the `external_fid` column, the name of the source table must be used as the starting point, rather than the search collection ID, otherwise the `href` to features in OAF collections will not be correct.

## Type of change

- Bugfix
- Configuration change

# Checklist:

- [x] I've double-checked the code in this PR myself
- [x] I've left the code better than before ([boy scout rule](https://wiki.c2.com/?BoyScoutRule))
- [x] The code is readable, comments are added that explain hard or non-obvious parts.
- [x] I've expanded/improved the (unit) tests, when applicable
- [x] I've run (unit) tests that prove my solution works
- [x] There's no sensitive information like credentials in my PR