### PR TITLE
fix(openapi): add bbox parameter refs

### DIFF
--- a/internal/engine/templates/openapi/features-search.go.json
+++ b/internal/engine/templates/openapi/features-search.go.json
@@ -29,6 +29,12 @@
             "$ref": "#/components/parameters/limit-search"
           },
           {
+            "$ref": "#/components/parameters/bbox"
+          }
+          {
+            "$ref": "#/components/parameters/bbox-crs"
+          }
+          {
             "$ref": "#/components/parameters/crs"
           }
         ],


### PR DESCRIPTION
# Description

Add references to the `bbox` and `bbox-crs` parameters in the OpenAPI spec.

## Type of change

- Bugfix

# Checklist:

- [x] I've double-checked the code in this PR myself
- [x] I've left the code better than before ([boy scout rule](https://wiki.c2.com/?BoyScoutRule))
- [x] The code is readable, comments are added that explain hard or non-obvious parts.
- [x] I've expanded/improved the (unit) tests, when applicable
- [x] I've run (unit) tests that prove my solution works
- [x] There's no sensitive information like credentials in my PR