### PR TITLE
feat: allow user to configure whether synonyms should or should not be included when determining exact matches

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -96,7 +96,7 @@ linters:
     - rowserrcheck  # checks whether Err of rows is checked successfully
     - sqlclosecheck  # checks that sql.Rows and sql.Stmt are closed
     - sloglint  # A Go linter that ensures consistent code style when using log/slog
-    - tenv  # detects using os.Setenv instead of t.Setenv since Go1.17
+    - usetesting  # detects using os.Setenv instead of t.Setenv since Go1.17
     - testableexamples  # checks if examples are testable (have an expected output)
     - tparallel  # detects inappropriate usage of t.Parallel() method in your Go test codes
     - unconvert  # removes unnecessary type conversions

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -52,6 +52,7 @@ const (
 	primarySuggestMultiplier = "primary-suggest-multiplier"
 	rankThreshold            = "rank-threshold"
 	preRankLimitMultiplier   = "pre-rank-limit-multiplier"
+	synonymsExactMatch       = "synonyms-exact-match"
 )
 
 var (
@@ -238,6 +239,13 @@ func main() {
 					Required: false,
 					Value:    10,
 				},
+				&cli.BoolFlag{
+					Name:     synonymsExactMatch,
+					EnvVars:  []string{strcase.ToScreamingSnake(synonymsExactMatch)},
+					Usage:    "When true synonyms are taken into account during exact match calculation",
+					Required: false,
+					Value:    false,
+				},
 			},
 			Action: func(c *cli.Context) error {
 				log.Println(c.Command.Usage)
@@ -271,6 +279,7 @@ func main() {
 					c.Float64(primarySuggestMultiplier),
 					c.Int(rankThreshold),
 					c.Int(preRankLimitMultiplier),
+					c.Bool(synonymsExactMatch),
 				)
 				if err != nil {
 					return err

--- a/internal/search/datasources/postgres/postgres.go
+++ b/internal/search/datasources/postgres/postgres.go
@@ -29,9 +29,13 @@ type Postgres struct {
 	primarySuggestMultiplier float64
 	rankThreshold            int
 	preRankLimitMultiplier   int
+	synonymsExactMatch       bool
 }
 
-func NewPostgres(dbConn string, queryTimeout time.Duration, searchIndex string, searchIndexSrid d.SRID, rankNormalization int, exactMatchMultiplier float64, primarySuggestMultiplier float64, rankThreshold int, preRankLimitMultiplier int) (*Postgres, error) {
+func NewPostgres(dbConn string, queryTimeout time.Duration, searchIndex string, searchIndexSrid d.SRID,
+	rankNormalization int, exactMatchMultiplier float64, primarySuggestMultiplier float64, rankThreshold int,
+	preRankLimitMultiplier int, synonymsExactMatch bool) (*Postgres, error) {
+
 	ctx := context.Background()
 	config, err := pgxpool.ParseConfig(dbConn)
 	if err != nil {
@@ -57,6 +61,7 @@ func NewPostgres(dbConn string, queryTimeout time.Duration, searchIndex string, 
 		primarySuggestMultiplier,
 		rankThreshold,
 		preRankLimitMultiplier,
+		synonymsExactMatch,
 	}, nil
 }
 
@@ -76,7 +81,7 @@ func (p *Postgres) SearchFeaturesAcrossCollections(ctx context.Context, searchQu
 	}
 	sql := makeSQL(p.searchIndex, srid, bboxFilter)
 	wildcardQuery := searchQuery.ToWildcardQuery()
-	exactMatchQuery := searchQuery.ToExactMatchQuery()
+	exactMatchQuery := searchQuery.ToExactMatchQuery(p.synonymsExactMatch)
 	names, versions, relevance := collections.NamesAndVersionsAndRelevance()
 	log.Printf("\nSEARCH QUERY (wildcard): %s\n", wildcardQuery)
 

--- a/internal/search/main.go
+++ b/internal/search/main.go
@@ -26,7 +26,10 @@ type Search struct {
 	json           *jsonFeatures
 }
 
-func NewSearch(e *engine.Engine, dbConn string, searchIndex string, searchIndexSrid int, rewritesFile string, synonymsFile string, rankNormalization int, exactMatchMultiplier float64, primarySuggestMultiplier float64, rankThreshold int, preRankLimitMultiplier int) (*Search, error) {
+func NewSearch(e *engine.Engine, dbConn string, searchIndex string, searchIndexSrid int, rewritesFile string,
+	synonymsFile string, rankNormalization int, exactMatchMultiplier float64, primarySuggestMultiplier float64,
+	rankThreshold int, preRankLimitMultiplier int, synonymsExactMatch bool) (*Search, error) {
+
 	queryExpansion, err := NewQueryExpansion(rewritesFile, synonymsFile)
 	if err != nil {
 		return nil, err
@@ -43,6 +46,7 @@ func NewSearch(e *engine.Engine, dbConn string, searchIndex string, searchIndexS
 			primarySuggestMultiplier,
 			rankThreshold,
 			preRankLimitMultiplier,
+			synonymsExactMatch,
 		),
 		json:           newJSONFeatures(e),
 		queryExpansion: queryExpansion,
@@ -137,7 +141,10 @@ func (s *Search) enrichFeaturesWithHref(fc *domain.FeatureCollection, outputCRS 
 	return nil
 }
 
-func newDatasource(e *engine.Engine, dbConn string, searchIndex string, searchIndexSrid int, rankNormalization int, exactMatchMultiplier float64, primarySuggestMultiplier float64, rankThreshold int, preRankLimitMultiplier int) ds.Datasource {
+func newDatasource(e *engine.Engine, dbConn string, searchIndex string, searchIndexSrid int, rankNormalization int,
+	exactMatchMultiplier float64, primarySuggestMultiplier float64, rankThreshold int,
+	preRankLimitMultiplier int, synonymsExactMatch bool) ds.Datasource {
+
 	datasource, err := postgres.NewPostgres(
 		dbConn,
 		timeout,
@@ -148,6 +155,7 @@ func newDatasource(e *engine.Engine, dbConn string, searchIndex string, searchIn
 		primarySuggestMultiplier,
 		rankThreshold,
 		preRankLimitMultiplier,
+		synonymsExactMatch,
 	)
 	if err != nil {
 		log.Fatalf("failed to create datasource: %v", err)

--- a/internal/search/main_test.go
+++ b/internal/search/main_test.go
@@ -59,19 +59,11 @@ func TestSearch(t *testing.T) {
 	assert.NoError(t, err)
 
 	// given search endpoint
-	searchEndpoint, err := NewSearch(
-		eng,
-		dbConn,
-		testSearchIndex,
-		domain.WGS84SRIDPostgis,
+	searchEndpoint, err := NewSearch(eng, dbConn, testSearchIndex, domain.WGS84SRIDPostgis,
 		"internal/search/testdata/rewrites.csv",
 		"internal/search/testdata/synonyms.csv",
-		1,
-		3.0,
-		1.01,
-		4000,
-		10,
-	)
+		1, 3.0, 1.01,
+		4000, 10, false)
 	assert.NoError(t, err)
 
 	// given empty search index

--- a/internal/search/query_expansion_fuzz_test.go
+++ b/internal/search/query_expansion_fuzz_test.go
@@ -34,7 +34,7 @@ func FuzzExpand(f *testing.F) {
 	f.Fuzz(func(t *testing.T, input string) {
 		expanded, err := queryExpansion.Expand(context.Background(), input)
 		assert.NoError(t, err)
-		query := expanded.ToExactMatchQuery()
+		query := expanded.ToExactMatchQuery(true)
 
 		assert.Truef(t, utf8.ValidString(query), "valid string")
 		if strings.TrimSpace(input) != "" {

--- a/internal/search/query_expansion_test.go
+++ b/internal/search/query_expansion_test.go
@@ -189,7 +189,7 @@ westgoeverneurstraat | westgoevstraat | westgouvstraat) & 1800
 			if tt.args.wildcard {
 				query = actual.ToWildcardQuery()
 			} else {
-				query = actual.ToExactMatchQuery()
+				query = actual.ToExactMatchQuery(true)
 			}
 			assert.Equal(t, strings.ReplaceAll(tt.want, "\n", ""), query, tt.args.searchQuery)
 		})

--- a/internal/search/testdata/expected-synonym-with-space.json
+++ b/internal/search/testdata/expected-synonym-with-space.json
@@ -19,7 +19,7 @@
         "displayName": "Spui 70 2511 BT s-Gravenhage",
         "highlight": "<b>Spui</b> 70 2511 BT <b>s</b>-<b>Gravenhage</b>",
         "href": "https://example.com/ogc/v1/collections/addresses/items/154?f=json",
-        "score": 0.038760408759117126
+        "score": 0.029046258330345156
       },
       "geometry": {
         "type": "Point",
@@ -48,7 +48,7 @@
         "displayName": "Spui 180 2511 BW 's-Gravenhage",
         "highlight": "<b>Spui</b> 180 2511 BW '<b>s</b>-<b>Gravenhage</b>",
         "href": "https://example.com/ogc/v1/collections/addresses/items/155?f=json",
-        "score": 0.038760408759117126
+        "score": 0.029046258330345156
       },
       "geometry": {
         "type": "Point",


### PR DESCRIPTION
# Description

Allow user to configure whether synonyms should or should not be included when determining exact matches

## Type of change

- Improvement of existing feature

# Checklist:

- [x] I've double-checked the code in this PR myself
- [ ] I've left the code better than before ([boy scout rule](https://wiki.c2.com/?BoyScoutRule))
- [ ] The code is readable, comments are added that explain hard or non-obvious parts.
- [x] I've expanded/improved the (unit) tests, when applicable
- [ ] I've run (unit) tests that prove my solution works
- [ ] There's no sensitive information like credentials in my PR